### PR TITLE
Add deploy runner with parallel execution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/mohitsharma44/dockcd
 go 1.25.0
 
 require (
-	golang.org/x/sync v0.19.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	golang.org/x/sync v0.19.0
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
 golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/deploy/compose.go
+++ b/internal/deploy/compose.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 )
 
 // CommandRunner is a function that runs a shell command in a directory.
@@ -12,7 +13,24 @@ type CommandRunner func(ctx context.Context, dir string, name string, args ...st
 
 // Deploy runs docker compose pull + up for a single stack.
 func Deploy(ctx context.Context, stack Stack, repoDir string, run CommandRunner) error {
+	if filepath.IsAbs(stack.Path) {
+		return fmt.Errorf("stack %q: path must be relative, got %q", stack.Name, stack.Path)
+	}
+
 	dir := filepath.Join(repoDir, stack.Path)
+
+	// Verify the resolved path is still within repoDir
+	resolvedDir, err := filepath.Abs(dir)
+	if err != nil {
+		return fmt.Errorf("stack %q: resolving path: %w", stack.Name, err)
+	}
+	resolvedRepo, err := filepath.Abs(repoDir)
+	if err != nil {
+		return fmt.Errorf("stack %q: resolving repo dir: %w", stack.Name, err)
+	}
+	if !strings.HasPrefix(resolvedDir, resolvedRepo) {
+		return fmt.Errorf("stack %q: path %q escapes repo directory", stack.Name, stack.Path)
+	}
 
 	if err := run(ctx, dir, "docker", "compose", "pull"); err != nil {
 		return fmt.Errorf("stack %q: compose pull: %w", stack.Name, err)

--- a/internal/deploy/compose_test.go
+++ b/internal/deploy/compose_test.go
@@ -44,3 +44,33 @@ func TestDeployRunsComposeUp(t *testing.T) {
 		t.Errorf("expected 'docker compose up', got %v", ranCommands)
 	}
 }
+
+func TestDeployRejectsAbsolutePath(t *testing.T) {
+	fakeRunner := func(ctx context.Context, dir string, name string, args ...string) error {
+		return nil
+	}
+
+	stack := Stack{Name: "evil", Path: "/etc/something"}
+	err := Deploy(context.Background(), stack, "/opt/repo", fakeRunner)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "must be relative") {
+		t.Fatalf("expected 'must be relative' error, got %v", err)
+	}
+}
+
+func TestDeployRejectsPathTraversal(t *testing.T) {
+	fakeRunner := func(ctx context.Context, dir string, name string, args ...string) error {
+		return nil
+	}
+
+	stack := Stack{Name: "evil", Path: "../../etc/something"}
+	err := Deploy(context.Background(), stack, "/opt/repo", fakeRunner)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "escapes repo") {
+		t.Fatalf("expected 'escapes repo' error, got %v", err)
+	}
+}

--- a/internal/deploy/runner.go
+++ b/internal/deploy/runner.go
@@ -14,14 +14,14 @@ func RunGroups(ctx context.Context, groups [][]Stack, repoDir string, run Comman
 		g, ctx := errgroup.WithContext(ctx)
 
 		for _, stack := range group {
-			// capture loop variable since its a goroutine
+			// capture loop variable since it's a goroutine
 			stack := stack
 			g.Go(func() error {
 				return Deploy(ctx, stack, repoDir, run)
 			})
 		}
 		if err := g.Wait(); err != nil {
-			return fmt.Errorf("group %d: %w", i, err)
+			return fmt.Errorf("group %d: %w", i+1, err)
 		}
 	}
 	return nil

--- a/internal/deploy/runner_test.go
+++ b/internal/deploy/runner_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 )
 
 func TestRunGroupsSequentialOrder(t *testing.T) {
@@ -48,16 +47,16 @@ func TestRunGroupsSequentialOrder(t *testing.T) {
 }
 
 func TestRunGroupsParallelWithinGroup(t *testing.T) {
-	// Two stacks in the same group should run concurrently
-	var mu sync.Mutex
-	startTimes := make(map[string]time.Time)
+	// Both goroutines signal when they start, then wait for a gate to open.
+	// If they're sequential, the second signal would never arrive while
+	// the first goroutine is still waiting on the gate.
+	started := make(chan string, 2)
+	gate := make(chan struct{})
 
 	fakeRunner := func(ctx context.Context, dir string, name string, args ...string) error {
 		if len(args) > 1 && args[1] == "up" {
-			mu.Lock()
-			startTimes[dir] = time.Now()
-			mu.Unlock()
-			time.Sleep(50 * time.Millisecond) // simulate work
+			started <- dir // signal: "I've started"
+			<-gate         // block until gate opens
 		}
 		return nil
 	}
@@ -69,20 +68,22 @@ func TestRunGroupsParallelWithinGroup(t *testing.T) {
 		},
 	}
 
-	err := RunGroups(context.Background(), groups, "/opt/repo", fakeRunner)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	done := make(chan error, 1)
+	go func() {
+		done <- RunGroups(context.Background(), groups, "/opt/repo", fakeRunner)
+	}()
 
-	// Both should have started within a small window (parallel)
-	tA := startTimes["/opt/repo/a/"]
-	tB := startTimes["/opt/repo/b/"]
-	diff := tA.Sub(tB)
-	if diff < 0 {
-		diff = -diff
-	}
-	if diff > 30*time.Millisecond {
-		t.Errorf("expected parallel start, but gap was %v", diff)
+	// Both should signal "started" since they're parallel.
+	// If they were sequential, we'd only get one signal (the other
+	// would be blocked waiting for the gate).
+	<-started
+	<-started
+
+	// Let them finish
+	close(gate)
+
+	if err := <-done; err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `compose.go` with `Deploy` function that runs `docker compose pull` + `up -d` for a single stack
- Add `runner.go` with `RunGroups` that orchestrates group-by-group deployment: sequential across groups, parallel within each group using `errgroup`
- Injectable `CommandRunner` type for testability (no real Docker needed in tests)
- Path traversal protection: rejects absolute paths and `../` escapes in stack paths
- Deterministic concurrency test using channels instead of time-based assertions

## Test plan
- [x] `go test ./internal/deploy/ -v -race` — all 15 tests pass, no race conditions
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)