### PR TITLE
Add auto-rollback with per-stack health checks

### DIFF
--- a/cmd/dockcd/main.go
+++ b/cmd/dockcd/main.go
@@ -97,6 +97,14 @@ func execCommand(ctx context.Context, dir string, name string, args ...string) e
 	return nil
 }
 
+// execCommandOutput runs a shell command and returns its output.
+// Used as the production deploy.OutputRunner for health checks.
+func execCommandOutput(ctx context.Context, dir string, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	return cmd.CombinedOutput()
+}
+
 func main() {
 	configPath := flag.String("config", "gitops.yaml", "path to gitops config file")
 	host := flag.String("host", "", "host name (overrides DOCKCD_HOST env and hostname)")
@@ -225,6 +233,7 @@ func main() {
 		PollInterval: *pollInterval,
 		InitialSync:  *initialSync,
 		Runner:       execCommand,
+		OutputRunner: execCommandOutput,
 		Metrics:      m,
 		Status:       status,
 		Logger:       logger,

--- a/examples/gitops.yaml
+++ b/examples/gitops.yaml
@@ -9,3 +9,5 @@ hosts:
         path: app/
         depends_on: [monitoring]
         post_deploy_delay: 30s
+        health_check_timeout: 90s
+        auto_rollback: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,12 +19,12 @@ type HostConfig struct {
 }
 
 type Stack struct {
-	Name               string        `yaml:"name"`
-	Path               string        `yaml:"path"`
-	DependsOn          []string      `yaml:"depends_on"`
-	PostDeployDelay    time.Duration `yaml:"post_deploy_delay"`
-	HealthCheckTimeout time.Duration `yaml:"health_check_timeout"`
-	AutoRollback       *bool         `yaml:"auto_rollback"`
+	Name               string         `yaml:"name"`
+	Path               string         `yaml:"path"`
+	DependsOn          []string       `yaml:"depends_on"`
+	PostDeployDelay    time.Duration  `yaml:"post_deploy_delay"`
+	HealthCheckTimeout *time.Duration `yaml:"health_check_timeout"`
+	AutoRollback       *bool          `yaml:"auto_rollback"`
 }
 
 // RollbackEnabled returns whether auto-rollback is enabled for this stack.
@@ -36,12 +36,13 @@ func (s *Stack) RollbackEnabled() bool {
 	return *s.AutoRollback
 }
 
-// HealthTimeout returns the health check timeout, defaulting to 60s.
+// HealthTimeout returns the health check timeout.
+// Defaults to 60s if not set. Returns 0 if explicitly set to 0 (disables health check).
 func (s *Stack) HealthTimeout() time.Duration {
-	if s.HealthCheckTimeout == 0 {
+	if s.HealthCheckTimeout == nil {
 		return 60 * time.Second
 	}
-	return s.HealthCheckTimeout
+	return *s.HealthCheckTimeout
 }
 
 func (s *Stack) UnmarshalYAML(value *yaml.Node) error {
@@ -72,7 +73,8 @@ func (s *Stack) UnmarshalYAML(value *yaml.Node) error {
 		if err != nil {
 			return fmt.Errorf("invalid health_check_timeout %q for stack %q: %w", raw.HealthCheckTimeout, raw.Name, err)
 		}
-		s.HealthCheckTimeout = d
+		timeout := d
+		s.HealthCheckTimeout = &timeout
 	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,18 +19,39 @@ type HostConfig struct {
 }
 
 type Stack struct {
-	Name            string        `yaml:"name"`
-	Path            string        `yaml:"path"`
-	DependsOn       []string      `yaml:"depends_on"`
-	PostDeployDelay time.Duration `yaml:"post_deploy_delay"`
+	Name               string        `yaml:"name"`
+	Path               string        `yaml:"path"`
+	DependsOn          []string      `yaml:"depends_on"`
+	PostDeployDelay    time.Duration `yaml:"post_deploy_delay"`
+	HealthCheckTimeout time.Duration `yaml:"health_check_timeout"`
+	AutoRollback       *bool         `yaml:"auto_rollback"`
+}
+
+// RollbackEnabled returns whether auto-rollback is enabled for this stack.
+// Defaults to true if not explicitly set.
+func (s *Stack) RollbackEnabled() bool {
+	if s.AutoRollback == nil {
+		return true
+	}
+	return *s.AutoRollback
+}
+
+// HealthTimeout returns the health check timeout, defaulting to 60s.
+func (s *Stack) HealthTimeout() time.Duration {
+	if s.HealthCheckTimeout == 0 {
+		return 60 * time.Second
+	}
+	return s.HealthCheckTimeout
 }
 
 func (s *Stack) UnmarshalYAML(value *yaml.Node) error {
 	var raw struct {
-		Name            string   `yaml:"name"`
-		Path            string   `yaml:"path"`
-		DependsOn       []string `yaml:"depends_on"`
-		PostDeployDelay string   `yaml:"post_deploy_delay"`
+		Name               string   `yaml:"name"`
+		Path               string   `yaml:"path"`
+		DependsOn          []string `yaml:"depends_on"`
+		PostDeployDelay    string   `yaml:"post_deploy_delay"`
+		HealthCheckTimeout string   `yaml:"health_check_timeout"`
+		AutoRollback       *bool    `yaml:"auto_rollback"`
 	}
 	if err := value.Decode(&raw); err != nil {
 		return err
@@ -38,12 +59,20 @@ func (s *Stack) UnmarshalYAML(value *yaml.Node) error {
 	s.Name = raw.Name
 	s.Path = raw.Path
 	s.DependsOn = raw.DependsOn
+	s.AutoRollback = raw.AutoRollback
 	if raw.PostDeployDelay != "" {
 		d, err := time.ParseDuration(raw.PostDeployDelay)
 		if err != nil {
 			return fmt.Errorf("invalid post_deploy_delay %q for stack %q: %w", raw.PostDeployDelay, raw.Name, err)
 		}
 		s.PostDeployDelay = d
+	}
+	if raw.HealthCheckTimeout != "" {
+		d, err := time.ParseDuration(raw.HealthCheckTimeout)
+		if err != nil {
+			return fmt.Errorf("invalid health_check_timeout %q for stack %q: %w", raw.HealthCheckTimeout, raw.Name, err)
+		}
+		s.HealthCheckTimeout = d
 	}
 	return nil
 }

--- a/internal/deploy/compose.go
+++ b/internal/deploy/compose.go
@@ -32,11 +32,11 @@ func Deploy(ctx context.Context, stack Stack, repoDir string, run CommandRunner)
 		return fmt.Errorf("stack %q: path %q escapes repo directory", stack.Name, stack.Path)
 	}
 
-	if err := run(ctx, dir, "docker", "compose", "pull"); err != nil {
+	if err := run(ctx, dir, "docker", "compose", "-p", stack.Name, "pull"); err != nil {
 		return fmt.Errorf("stack %q: compose pull: %w", stack.Name, err)
 	}
 
-	if err := run(ctx, dir, "docker", "compose", "up", "-d", "--remove-orphans"); err != nil {
+	if err := run(ctx, dir, "docker", "compose", "-p", stack.Name, "up", "-d", "--remove-orphans"); err != nil {
 		return fmt.Errorf("stack %q: compose up: %w", stack.Name, err)
 	}
 

--- a/internal/deploy/compose_test.go
+++ b/internal/deploy/compose_test.go
@@ -30,18 +30,18 @@ func TestDeployRunsComposeUp(t *testing.T) {
 	foundPull := false
 	foundUp := false
 	for _, cmd := range ranCommands {
-		if strings.Contains(cmd, "compose pull") {
+		if strings.Contains(cmd, "compose") && strings.Contains(cmd, "pull") {
 			foundPull = true
 		}
-		if strings.Contains(cmd, "compose up") {
+		if strings.Contains(cmd, "compose") && strings.Contains(cmd, "up") {
 			foundUp = true
 		}
 	}
 	if !foundPull {
-		t.Errorf("expected 'docker compose pull', got %v", ranCommands)
+		t.Errorf("expected 'docker compose ... pull', got %v", ranCommands)
 	}
 	if !foundUp {
-		t.Errorf("expected 'docker compose up', got %v", ranCommands)
+		t.Errorf("expected 'docker compose ... up', got %v", ranCommands)
 	}
 }
 

--- a/internal/deploy/graph.go
+++ b/internal/deploy/graph.go
@@ -1,6 +1,9 @@
 package deploy
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // ErrCycleDetected is returned when stacks have circular dependencies.
 var ErrCycleDetected = fmt.Errorf("dependency cycle detected")
@@ -8,9 +11,11 @@ var ErrCycleDetected = fmt.Errorf("dependency cycle detected")
 // Stack is a minimal graph input type, intentionally decoupled from
 // configuration schema types (e.g., internal/config.Stack).
 type Stack struct {
-	Name      string
-	Path      string
-	DependsOn []string
+	Name               string
+	Path               string
+	DependsOn          []string
+	HealthCheckTimeout time.Duration
+	AutoRollback       bool
 }
 
 // BuildGraph takes a list of stacks and returns parallel deployment groups

--- a/internal/deploy/health.go
+++ b/internal/deploy/health.go
@@ -21,7 +21,7 @@ type ContainerStatus struct {
 
 // HealthCheck polls `docker compose ps` until all containers are running
 // (and healthy, if they define a HEALTHCHECK) or the timeout expires.
-func HealthCheck(ctx context.Context, dir string, timeout time.Duration, run OutputRunner) error {
+func HealthCheck(ctx context.Context, dir, projectName string, timeout time.Duration, run OutputRunner) error {
 	deadline := time.After(timeout)
 	// Check immediately, then every 5 seconds.
 	ticker := time.NewTicker(5 * time.Second)
@@ -29,7 +29,7 @@ func HealthCheck(ctx context.Context, dir string, timeout time.Duration, run Out
 
 	var lastErr error
 	for {
-		healthy, err := checkContainers(ctx, dir, run)
+		healthy, err := checkContainers(ctx, dir, projectName, run)
 		if err == nil && healthy {
 			return nil
 		}
@@ -50,8 +50,8 @@ func HealthCheck(ctx context.Context, dir string, timeout time.Duration, run Out
 	}
 }
 
-func checkContainers(ctx context.Context, dir string, run OutputRunner) (bool, error) {
-	out, err := run(ctx, dir, "docker", "compose", "ps", "--format", "json")
+func checkContainers(ctx context.Context, dir, projectName string, run OutputRunner) (bool, error) {
+	out, err := run(ctx, dir, "docker", "compose", "-p", projectName, "ps", "--format", "json")
 	if err != nil {
 		return false, fmt.Errorf("compose ps: %w", err)
 	}

--- a/internal/deploy/health.go
+++ b/internal/deploy/health.go
@@ -76,8 +76,24 @@ func checkContainers(ctx context.Context, dir string, run OutputRunner) (bool, e
 	return true, nil
 }
 
-// parseComposePS parses the NDJSON output from `docker compose ps --format json`.
+// parseComposePS parses docker compose ps --format json output.
+// Supports both JSON array format (newer compose) and NDJSON (one object per line).
 func parseComposePS(data []byte) ([]ContainerStatus, error) {
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+
+	// Try JSON array first (newer docker compose versions).
+	if trimmed[0] == '[' {
+		var containers []ContainerStatus
+		if err := json.Unmarshal(trimmed, &containers); err != nil {
+			return nil, fmt.Errorf("parsing container status array: %w", err)
+		}
+		return containers, nil
+	}
+
+	// Fall back to NDJSON (one JSON object per line).
 	var containers []ContainerStatus
 	scanner := bufio.NewScanner(bytes.NewReader(data))
 	for scanner.Scan() {

--- a/internal/deploy/health.go
+++ b/internal/deploy/health.go
@@ -1,0 +1,95 @@
+package deploy
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// OutputRunner runs a command and returns its combined output.
+type OutputRunner func(ctx context.Context, dir, name string, args ...string) ([]byte, error)
+
+// ContainerStatus represents one entry from `docker compose ps --format json`.
+type ContainerStatus struct {
+	Name   string `json:"Name"`
+	State  string `json:"State"`
+	Health string `json:"Health"`
+}
+
+// HealthCheck polls `docker compose ps` until all containers are running
+// (and healthy, if they define a HEALTHCHECK) or the timeout expires.
+func HealthCheck(ctx context.Context, dir string, timeout time.Duration, run OutputRunner) error {
+	deadline := time.After(timeout)
+	// Check immediately, then every 5 seconds.
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	var lastErr error
+	for {
+		healthy, err := checkContainers(ctx, dir, run)
+		if err == nil && healthy {
+			return nil
+		}
+		if err != nil {
+			lastErr = err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadline:
+			if lastErr != nil {
+				return fmt.Errorf("health check timed out after %s: %w", timeout, lastErr)
+			}
+			return fmt.Errorf("health check timed out after %s: containers not healthy", timeout)
+		case <-ticker.C:
+		}
+	}
+}
+
+func checkContainers(ctx context.Context, dir string, run OutputRunner) (bool, error) {
+	out, err := run(ctx, dir, "docker", "compose", "ps", "--format", "json")
+	if err != nil {
+		return false, fmt.Errorf("compose ps: %w", err)
+	}
+
+	containers, err := parseComposePS(out)
+	if err != nil {
+		return false, err
+	}
+
+	if len(containers) == 0 {
+		return false, fmt.Errorf("no containers found")
+	}
+
+	for _, c := range containers {
+		if c.State != "running" {
+			return false, nil
+		}
+		if c.Health != "" && c.Health != "healthy" {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// parseComposePS parses the NDJSON output from `docker compose ps --format json`.
+func parseComposePS(data []byte) ([]ContainerStatus, error) {
+	var containers []ContainerStatus
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var c ContainerStatus
+		if err := json.Unmarshal(line, &c); err != nil {
+			return nil, fmt.Errorf("parsing container status: %w", err)
+		}
+		containers = append(containers, c)
+	}
+	return containers, scanner.Err()
+}

--- a/internal/deploy/health_test.go
+++ b/internal/deploy/health_test.go
@@ -27,6 +27,11 @@ func TestParseComposePS(t *testing.T) {
 			want: 2,
 		},
 		{
+			name:  "json array format",
+			input: `[{"Name":"web-1","State":"running","Health":"healthy"},{"Name":"db-1","State":"running","Health":""}]`,
+			want:  2,
+		},
+		{
 			name:  "empty output",
 			input: "",
 			want:  0,

--- a/internal/deploy/health_test.go
+++ b/internal/deploy/health_test.go
@@ -69,7 +69,7 @@ func TestCheckContainersHealthy(t *testing.T) {
 `), nil
 	}
 
-	healthy, err := checkContainers(context.Background(), "/tmp", run)
+	healthy, err := checkContainers(context.Background(), "/tmp", "test", run)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestCheckContainersUnhealthy(t *testing.T) {
 `), nil
 	}
 
-	healthy, err := checkContainers(context.Background(), "/tmp", run)
+	healthy, err := checkContainers(context.Background(), "/tmp", "test", run)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestCheckContainersHealthCheckUnhealthy(t *testing.T) {
 		return []byte(`{"Name":"web-1","State":"running","Health":"unhealthy"}` + "\n"), nil
 	}
 
-	healthy, err := checkContainers(context.Background(), "/tmp", run)
+	healthy, err := checkContainers(context.Background(), "/tmp", "test", run)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestCheckContainersEmpty(t *testing.T) {
 		return []byte(""), nil
 	}
 
-	_, err := checkContainers(context.Background(), "/tmp", run)
+	_, err := checkContainers(context.Background(), "/tmp", "test", run)
 	if err == nil {
 		t.Fatal("expected error for empty containers")
 	}
@@ -124,7 +124,7 @@ func TestCheckContainersCommandError(t *testing.T) {
 		return nil, fmt.Errorf("command failed")
 	}
 
-	_, err := checkContainers(context.Background(), "/tmp", run)
+	_, err := checkContainers(context.Background(), "/tmp", "test", run)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -136,7 +136,7 @@ func TestHealthCheckTimeout(t *testing.T) {
 		return []byte(`{"Name":"web-1","State":"exited","Health":""}` + "\n"), nil
 	}
 
-	err := HealthCheck(context.Background(), "/tmp", 50*time.Millisecond, run)
+	err := HealthCheck(context.Background(), "/tmp", "test", 50*time.Millisecond, run)
 	if err == nil {
 		t.Fatal("expected timeout error")
 	}
@@ -147,7 +147,7 @@ func TestHealthCheckSucceeds(t *testing.T) {
 		return []byte(`{"Name":"web-1","State":"running","Health":""}` + "\n"), nil
 	}
 
-	err := HealthCheck(context.Background(), "/tmp", 5*time.Second, run)
+	err := HealthCheck(context.Background(), "/tmp", "test", 5*time.Second, run)
 	if err != nil {
 		t.Fatalf("expected health check to pass: %v", err)
 	}

--- a/internal/deploy/health_test.go
+++ b/internal/deploy/health_test.go
@@ -1,0 +1,149 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestParseComposePS(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    int
+		wantErr bool
+	}{
+		{
+			name:  "single healthy container",
+			input: `{"Name":"web-1","State":"running","Health":"healthy"}` + "\n",
+			want:  1,
+		},
+		{
+			name: "multiple containers",
+			input: `{"Name":"web-1","State":"running","Health":"healthy"}
+{"Name":"db-1","State":"running","Health":""}
+`,
+			want: 2,
+		},
+		{
+			name:  "empty output",
+			input: "",
+			want:  0,
+		},
+		{
+			name:    "invalid json",
+			input:   "not json\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			containers, err := parseComposePS([]byte(tt.input))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(containers) != tt.want {
+				t.Errorf("expected %d containers, got %d", tt.want, len(containers))
+			}
+		})
+	}
+}
+
+func TestCheckContainersHealthy(t *testing.T) {
+	run := func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+		return []byte(`{"Name":"web-1","State":"running","Health":"healthy"}
+{"Name":"db-1","State":"running","Health":""}
+`), nil
+	}
+
+	healthy, err := checkContainers(context.Background(), "/tmp", run)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !healthy {
+		t.Error("expected healthy")
+	}
+}
+
+func TestCheckContainersUnhealthy(t *testing.T) {
+	run := func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+		return []byte(`{"Name":"web-1","State":"running","Health":"healthy"}
+{"Name":"db-1","State":"exited","Health":""}
+`), nil
+	}
+
+	healthy, err := checkContainers(context.Background(), "/tmp", run)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if healthy {
+		t.Error("expected unhealthy")
+	}
+}
+
+func TestCheckContainersHealthCheckUnhealthy(t *testing.T) {
+	run := func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+		return []byte(`{"Name":"web-1","State":"running","Health":"unhealthy"}` + "\n"), nil
+	}
+
+	healthy, err := checkContainers(context.Background(), "/tmp", run)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if healthy {
+		t.Error("expected unhealthy when Health=unhealthy")
+	}
+}
+
+func TestCheckContainersEmpty(t *testing.T) {
+	run := func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+		return []byte(""), nil
+	}
+
+	_, err := checkContainers(context.Background(), "/tmp", run)
+	if err == nil {
+		t.Fatal("expected error for empty containers")
+	}
+}
+
+func TestCheckContainersCommandError(t *testing.T) {
+	run := func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("command failed")
+	}
+
+	_, err := checkContainers(context.Background(), "/tmp", run)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestHealthCheckTimeout(t *testing.T) {
+	// Runner always returns unhealthy.
+	run := func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+		return []byte(`{"Name":"web-1","State":"exited","Health":""}` + "\n"), nil
+	}
+
+	err := HealthCheck(context.Background(), "/tmp", 50*time.Millisecond, run)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+}
+
+func TestHealthCheckSucceeds(t *testing.T) {
+	run := func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+		return []byte(`{"Name":"web-1","State":"running","Health":""}` + "\n"), nil
+	}
+
+	err := HealthCheck(context.Background(), "/tmp", 5*time.Second, run)
+	if err != nil {
+		t.Fatalf("expected health check to pass: %v", err)
+	}
+}

--- a/internal/deploy/runner_test.go
+++ b/internal/deploy/runner_test.go
@@ -8,6 +8,15 @@ import (
 	"testing"
 )
 
+func containsArg(args []string, target string) bool {
+	for _, a := range args {
+		if a == target {
+			return true
+		}
+	}
+	return false
+}
+
 func TestRunGroupsSequentialOrder(t *testing.T) {
 	// Track the order stacks are deployed
 	var mu sync.Mutex
@@ -15,7 +24,7 @@ func TestRunGroupsSequentialOrder(t *testing.T) {
 
 	fakeRunner := func(ctx context.Context, dir string, name string, args ...string) error {
 		// Only track compose up calls
-		if len(args) > 1 && args[1] == "up" {
+		if containsArg(args, "up") {
 			mu.Lock()
 			order = append(order, dir)
 			mu.Unlock()
@@ -54,7 +63,7 @@ func TestRunGroupsParallelWithinGroup(t *testing.T) {
 	gate := make(chan struct{})
 
 	fakeRunner := func(ctx context.Context, dir string, name string, args ...string) error {
-		if len(args) > 1 && args[1] == "up" {
+		if containsArg(args, "up") {
 			started <- dir // signal: "I've started"
 			<-gate         // block until gate opens
 		}
@@ -92,7 +101,7 @@ func TestRunGroupsStopsOnError(t *testing.T) {
 	var mu sync.Mutex
 
 	fakeRunner := func(ctx context.Context, dir string, name string, args ...string) error {
-		if len(args) > 1 && args[1] == "up" {
+		if containsArg(args, "up") {
 			mu.Lock()
 			deployCount++
 			mu.Unlock()

--- a/internal/git/poller.go
+++ b/internal/git/poller.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 )
 
 // State is the JSON-serialized state file format.
@@ -22,6 +23,7 @@ type Poller struct {
 	stateFile string
 	branch    string
 	state     State
+	mu        sync.Mutex // protects state and file writes
 }
 
 func NewPoller(repoURL, localDir string) *Poller {
@@ -69,6 +71,13 @@ func (p *Poller) SetStateFile(path string) {
 }
 
 func (p *Poller) saveState() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.saveStateLocked()
+}
+
+// saveStateLocked writes state to disk. Caller must hold p.mu.
+func (p *Poller) saveStateLocked() error {
 	if p.stateFile == "" {
 		return nil
 	}
@@ -108,13 +117,17 @@ func (p *Poller) LoadState() error {
 // LastSuccessfulCommit returns the last commit at which the given stack
 // was successfully deployed. Returns empty string if no history.
 func (p *Poller) LastSuccessfulCommit(stack string) string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	return p.state.LastSuccessfulCommits[stack]
 }
 
 // SetLastSuccessfulCommit records a successful deploy for a stack and persists state.
 func (p *Poller) SetLastSuccessfulCommit(stack, hash string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.state.LastSuccessfulCommits[stack] = hash
-	return p.saveState()
+	return p.saveStateLocked()
 }
 
 // ExtractAtCommit writes the files under pathPrefix at the given commit to destDir.

--- a/internal/git/poller.go
+++ b/internal/git/poller.go
@@ -1,11 +1,19 @@
 package git
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
+
+// State is the JSON-serialized state file format.
+type State struct {
+	LastHash              string            `json:"last_hash"`
+	LastSuccessfulCommits map[string]string `json:"last_successful_commits"`
+}
 
 type Poller struct {
 	repoURL   string
@@ -13,12 +21,14 @@ type Poller struct {
 	lastHash  string
 	stateFile string
 	branch    string
+	state     State
 }
 
 func NewPoller(repoURL, localDir string) *Poller {
 	return &Poller{
 		repoURL:  repoURL,
 		localDir: localDir,
+		state:    State{LastSuccessfulCommits: make(map[string]string)},
 	}
 }
 
@@ -46,6 +56,7 @@ func (p *Poller) Clone() error {
 		return fmt.Errorf("git rev-parse HEAD after clone: %w", err)
 	}
 	p.lastHash = strings.TrimSpace(string(out))
+	p.state.LastHash = p.lastHash
 	return p.saveState()
 }
 
@@ -61,9 +72,16 @@ func (p *Poller) saveState() error {
 	if p.stateFile == "" {
 		return nil
 	}
-	return os.WriteFile(p.stateFile, []byte(p.lastHash), 0644)
+	p.state.LastHash = p.lastHash
+	data, err := json.MarshalIndent(p.state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling state: %w", err)
+	}
+	return os.WriteFile(p.stateFile, data, 0644)
 }
 
+// LoadState reads the state file. Supports both the legacy plain-text
+// format (just a commit hash) and the new JSON format.
 func (p *Poller) LoadState() error {
 	if p.stateFile == "" {
 		return nil
@@ -72,7 +90,71 @@ func (p *Poller) LoadState() error {
 	if err != nil {
 		return fmt.Errorf("reading state file: %w", err)
 	}
-	p.lastHash = strings.TrimSpace(string(data))
+
+	var state State
+	if err := json.Unmarshal(data, &state); err != nil {
+		// Legacy format: plain text hash
+		state.LastHash = strings.TrimSpace(string(data))
+		state.LastSuccessfulCommits = make(map[string]string)
+	}
+	if state.LastSuccessfulCommits == nil {
+		state.LastSuccessfulCommits = make(map[string]string)
+	}
+	p.state = state
+	p.lastHash = state.LastHash
+	return nil
+}
+
+// LastSuccessfulCommit returns the last commit at which the given stack
+// was successfully deployed. Returns empty string if no history.
+func (p *Poller) LastSuccessfulCommit(stack string) string {
+	return p.state.LastSuccessfulCommits[stack]
+}
+
+// SetLastSuccessfulCommit records a successful deploy for a stack and persists state.
+func (p *Poller) SetLastSuccessfulCommit(stack, hash string) error {
+	p.state.LastSuccessfulCommits[stack] = hash
+	return p.saveState()
+}
+
+// ExtractAtCommit writes the files under pathPrefix at the given commit to destDir.
+// Uses `git show` to avoid modifying the working tree.
+func (p *Poller) ExtractAtCommit(commit, pathPrefix, destDir string) error {
+	// List files at the commit under the path prefix.
+	cmd := exec.Command("git", "ls-tree", "-r", "--name-only", commit, pathPrefix+"/")
+	cmd.Dir = p.localDir
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("listing files at %s:%s: %w", commit, pathPrefix, err)
+	}
+
+	files := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(files) == 0 || (len(files) == 1 && files[0] == "") {
+		return fmt.Errorf("no files found at %s:%s", commit, pathPrefix)
+	}
+
+	for _, file := range files {
+		// Extract file content.
+		cmd = exec.Command("git", "show", commit+":"+file)
+		cmd.Dir = p.localDir
+		content, err := cmd.Output()
+		if err != nil {
+			return fmt.Errorf("extracting %s:%s: %w", commit, file, err)
+		}
+
+		// Write to destDir, preserving the relative path under pathPrefix.
+		relPath, err := filepath.Rel(pathPrefix, file)
+		if err != nil {
+			return fmt.Errorf("computing relative path for %s: %w", file, err)
+		}
+		destPath := filepath.Join(destDir, relPath)
+		if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(destPath, content, 0644); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -25,6 +25,9 @@ type Metrics struct {
 
 	// StackHealthy tracks whether each stack is healthy (1) or degraded (0).
 	StackHealthy metric.Float64Gauge
+
+	// RollbackTotal counts rollbacks by result (success/failure).
+	RollbackTotal metric.Int64Counter
 }
 
 // Setup creates an OTel MeterProvider backed by a Prometheus exporter.
@@ -99,6 +102,13 @@ func New(meter metric.Meter) (*Metrics, error) {
 		return nil, err
 	}
 
+	rollbackTotal, err := meter.Int64Counter("dockcd_rollback_total",
+		metric.WithDescription("Total rollbacks by result (success/failure)"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Metrics{
 		LastSyncTimestamp: lastSync,
 		DeployTotal:       deployTotal,
@@ -106,5 +116,6 @@ func New(meter metric.Meter) (*Metrics, error) {
 		GitLastCommit:     gitLastCommit,
 		PollTotal:         pollTotal,
 		StackHealthy:      stackHealthy,
+		RollbackTotal:     rollbackTotal,
 	}, nil
 }

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -2,6 +2,7 @@ package reconciler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -17,6 +18,10 @@ import (
 	"github.com/mohitsharma44/dockcd/internal/metrics"
 	"github.com/mohitsharma44/dockcd/internal/server"
 )
+
+// ErrRolledBack is returned when a stack was rolled back to its last known
+// good version. The stack is running but degraded (not at HEAD).
+var ErrRolledBack = fmt.Errorf("stack rolled back")
 
 // GitPoller abstracts git operations so the reconciler can be tested
 // without real git repos.
@@ -200,9 +205,19 @@ func (r *Reconciler) reconcile(ctx context.Context) error {
 	err = r.deployGroups(ctx, groups, commitHash)
 	duration := time.Since(start)
 
-	if err != nil {
+	if err != nil && !errors.Is(err, ErrRolledBack) {
 		r.recordDeployMetric(ctx, "failure", duration)
 		return fmt.Errorf("deploy: %w", err)
+	}
+
+	if errors.Is(err, ErrRolledBack) {
+		r.recordDeployMetric(ctx, "partial", duration)
+		r.status.Update(time.Now(), r.poller.LastHash())
+		r.logger.Warn("deploy complete with rollbacks",
+			"duration", duration,
+			"stacks", changedNames,
+		)
+		return nil
 	}
 
 	r.recordDeployMetric(ctx, "success", duration)
@@ -217,7 +232,10 @@ func (r *Reconciler) reconcile(ctx context.Context) error {
 
 // deployGroups deploys groups sequentially, stacks within a group in parallel.
 // Each stack gets health-checked and optionally rolled back on failure.
+// A successful rollback (ErrRolledBack) does not stop deployment of downstream groups.
+// Only hard failures (deploy error, failed rollback) halt the pipeline.
 func (r *Reconciler) deployGroups(ctx context.Context, groups [][]deploy.Stack, commitHash string) error {
+	var rolledBack bool
 	for i, group := range groups {
 		g, gCtx := errgroup.WithContext(ctx)
 		for _, stack := range group {
@@ -226,8 +244,15 @@ func (r *Reconciler) deployGroups(ctx context.Context, groups [][]deploy.Stack, 
 			})
 		}
 		if err := g.Wait(); err != nil {
+			if errors.Is(err, ErrRolledBack) {
+				rolledBack = true
+				continue // stack is running (rolled back), proceed with downstream
+			}
 			return fmt.Errorf("group %d: %w", i+1, err)
 		}
+	}
+	if rolledBack {
+		return ErrRolledBack
 	}
 	return nil
 }
@@ -310,17 +335,23 @@ func (r *Reconciler) rollback(ctx context.Context, stack deploy.Stack, currentCo
 	r.recordRollbackMetric(ctx, stack.Name, "success")
 	r.logger.Warn("rollback complete, stack is degraded",
 		"stack", stack.Name, "running_commit", lastGood)
-	return nil
+	return fmt.Errorf("stack %q: %w to %s", stack.Name, ErrRolledBack, lastGood)
 }
 
 // deployAll deploys all configured stacks in dependency order.
+// Uses deployGroups to run health checks and establish rollback history.
 func (r *Reconciler) deployAll(ctx context.Context) error {
 	stacks := r.configToDeployStacks(r.hostStacks)
 	groups, err := deploy.BuildGraph(stacks)
 	if err != nil {
 		return fmt.Errorf("building deploy graph: %w", err)
 	}
-	return deploy.RunGroups(ctx, groups, r.repoDir, r.runner)
+	commitHash := r.poller.LastHash()
+	err = r.deployGroups(ctx, groups, commitHash)
+	if errors.Is(err, ErrRolledBack) {
+		return nil // some stacks rolled back but are running
+	}
+	return err
 }
 
 // buildStackPaths returns a map of stack name → path relative to repo root.

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -237,10 +237,12 @@ func (r *Reconciler) reconcile(ctx context.Context) error {
 func (r *Reconciler) deployGroups(ctx context.Context, groups [][]deploy.Stack, commitHash string) error {
 	var rolledBack bool
 	for i, group := range groups {
-		g, gCtx := errgroup.WithContext(ctx)
+		// Use a plain errgroup (no context cancellation) so that a
+		// rollback in one stack doesn't cancel sibling deploys.
+		var g errgroup.Group
 		for _, stack := range group {
 			g.Go(func() error {
-				return r.deployStack(gCtx, stack, commitHash)
+				return r.deployStack(ctx, stack, commitHash)
 			})
 		}
 		if err := g.Wait(); err != nil {
@@ -267,7 +269,7 @@ func (r *Reconciler) deployStack(ctx context.Context, stack deploy.Stack, commit
 	// Health check (skip if no OutputRunner or timeout is 0).
 	if r.outputRunner != nil && stack.HealthCheckTimeout > 0 {
 		dir := filepath.Join(r.repoDir, stack.Path)
-		if err := deploy.HealthCheck(ctx, dir, stack.HealthCheckTimeout, r.outputRunner); err != nil {
+		if err := deploy.HealthCheck(ctx, dir, stack.Name, stack.HealthCheckTimeout, r.outputRunner); err != nil {
 			r.logger.Warn("health check failed",
 				"stack", stack.Name, "error", err)
 

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -10,6 +10,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	otelmetric "go.opentelemetry.io/otel/metric"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/mohitsharma44/dockcd/internal/config"
 	"github.com/mohitsharma44/dockcd/internal/deploy"
@@ -25,6 +26,9 @@ type GitPoller interface {
 	ChangedStacks(sinceHash string, stackPaths map[string]string) ([]string, error)
 	LastHash() string
 	LoadState() error
+	LastSuccessfulCommit(stack string) string
+	SetLastSuccessfulCommit(stack, hash string) error
+	ExtractAtCommit(commit, pathPrefix, destDir string) error
 }
 
 // Config holds all dependencies for the Reconciler.
@@ -37,6 +41,7 @@ type Config struct {
 	PollInterval time.Duration
 	InitialSync  bool
 	Runner       deploy.CommandRunner
+	OutputRunner deploy.OutputRunner
 	Metrics      *metrics.Metrics
 	Status       *server.Status
 	Logger       *slog.Logger
@@ -53,6 +58,7 @@ type Reconciler struct {
 	pollInterval time.Duration
 	initialSync  bool
 	runner       deploy.CommandRunner
+	outputRunner deploy.OutputRunner
 	metrics      *metrics.Metrics
 	status       *server.Status
 	logger       *slog.Logger
@@ -87,6 +93,7 @@ func New(cfg Config) (*Reconciler, error) {
 		pollInterval: cfg.PollInterval,
 		initialSync:  cfg.InitialSync,
 		runner:       cfg.Runner,
+		outputRunner: cfg.OutputRunner,
 		metrics:      cfg.Metrics,
 		status:       cfg.Status,
 		logger:       logger,
@@ -189,7 +196,8 @@ func (r *Reconciler) reconcile(ctx context.Context) error {
 	}
 
 	start := time.Now()
-	err = deploy.RunGroups(ctx, groups, r.repoDir, r.runner)
+	commitHash := r.poller.LastHash()
+	err = r.deployGroups(ctx, groups, commitHash)
 	duration := time.Since(start)
 
 	if err != nil {
@@ -207,6 +215,104 @@ func (r *Reconciler) reconcile(ctx context.Context) error {
 	return nil
 }
 
+// deployGroups deploys groups sequentially, stacks within a group in parallel.
+// Each stack gets health-checked and optionally rolled back on failure.
+func (r *Reconciler) deployGroups(ctx context.Context, groups [][]deploy.Stack, commitHash string) error {
+	for i, group := range groups {
+		g, gCtx := errgroup.WithContext(ctx)
+		for _, stack := range group {
+			g.Go(func() error {
+				return r.deployStack(gCtx, stack, commitHash)
+			})
+		}
+		if err := g.Wait(); err != nil {
+			return fmt.Errorf("group %d: %w", i+1, err)
+		}
+	}
+	return nil
+}
+
+// deployStack deploys a single stack, health-checks it, and rolls back on failure.
+func (r *Reconciler) deployStack(ctx context.Context, stack deploy.Stack, commitHash string) error {
+	if err := deploy.Deploy(ctx, stack, r.repoDir, r.runner); err != nil {
+		r.markStackHealth(ctx, stack.Name, false)
+		return err
+	}
+
+	// Health check (skip if no OutputRunner or timeout is 0).
+	if r.outputRunner != nil && stack.HealthCheckTimeout > 0 {
+		dir := filepath.Join(r.repoDir, stack.Path)
+		if err := deploy.HealthCheck(ctx, dir, stack.HealthCheckTimeout, r.outputRunner); err != nil {
+			r.logger.Warn("health check failed",
+				"stack", stack.Name, "error", err)
+
+			if !stack.AutoRollback {
+				r.markStackHealth(ctx, stack.Name, false)
+				return fmt.Errorf("stack %q unhealthy, auto_rollback disabled", stack.Name)
+			}
+
+			return r.rollback(ctx, stack, commitHash)
+		}
+	}
+
+	// Healthy — record successful commit.
+	if err := r.poller.SetLastSuccessfulCommit(stack.Name, commitHash); err != nil {
+		r.logger.Error("failed to save last successful commit", "stack", stack.Name, "error", err)
+	}
+	r.markStackHealth(ctx, stack.Name, true)
+	return nil
+}
+
+// rollback deploys the last known good version of a stack.
+func (r *Reconciler) rollback(ctx context.Context, stack deploy.Stack, currentCommit string) error {
+	lastGood := r.poller.LastSuccessfulCommit(stack.Name)
+	if lastGood == "" {
+		r.markStackHealth(ctx, stack.Name, false)
+		r.recordRollbackMetric(ctx, stack.Name, "failure")
+		return fmt.Errorf("stack %q: no previous successful commit to rollback to", stack.Name)
+	}
+	if lastGood == currentCommit {
+		r.markStackHealth(ctx, stack.Name, false)
+		r.recordRollbackMetric(ctx, stack.Name, "failure")
+		return fmt.Errorf("stack %q: current commit IS the last successful commit", stack.Name)
+	}
+
+	r.logger.Info("rolling back",
+		"stack", stack.Name,
+		"from_commit", currentCommit,
+		"to_commit", lastGood,
+	)
+
+	tmpDir, err := os.MkdirTemp("", "dockcd-rollback-*")
+	if err != nil {
+		r.markStackHealth(ctx, stack.Name, false)
+		r.recordRollbackMetric(ctx, stack.Name, "failure")
+		return fmt.Errorf("creating temp dir for rollback: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	if err := r.poller.ExtractAtCommit(lastGood, stack.Path, tmpDir); err != nil {
+		r.markStackHealth(ctx, stack.Name, false)
+		r.recordRollbackMetric(ctx, stack.Name, "failure")
+		return fmt.Errorf("extracting files at %s: %w", lastGood, err)
+	}
+
+	// Deploy from temp dir using a stack with path "." since files are at root.
+	rollbackStack := deploy.Stack{Name: stack.Name, Path: "."}
+	if err := deploy.Deploy(ctx, rollbackStack, tmpDir, r.runner); err != nil {
+		r.markStackHealth(ctx, stack.Name, false)
+		r.recordRollbackMetric(ctx, stack.Name, "failure")
+		return fmt.Errorf("rollback deploy failed for %q: %w", stack.Name, err)
+	}
+
+	// Rollback succeeded — stack is running but degraded (not at HEAD).
+	r.markStackHealth(ctx, stack.Name, false)
+	r.recordRollbackMetric(ctx, stack.Name, "success")
+	r.logger.Warn("rollback complete, stack is degraded",
+		"stack", stack.Name, "running_commit", lastGood)
+	return nil
+}
+
 // deployAll deploys all configured stacks in dependency order.
 func (r *Reconciler) deployAll(ctx context.Context) error {
 	stacks := r.configToDeployStacks(r.hostStacks)
@@ -218,7 +324,6 @@ func (r *Reconciler) deployAll(ctx context.Context) error {
 }
 
 // buildStackPaths returns a map of stack name → path relative to repo root.
-// Used by ChangedStacks to match git diff output against stack paths.
 func (r *Reconciler) buildStackPaths() map[string]string {
 	paths := make(map[string]string, len(r.hostStacks))
 	for _, s := range r.hostStacks {
@@ -249,9 +354,11 @@ func (r *Reconciler) filterChangedStacks(changedNames []string) []deploy.Stack {
 			}
 		}
 		stacks = append(stacks, deploy.Stack{
-			Name:      cs.Name,
-			Path:      filepath.Join(r.basePath, cs.Path),
-			DependsOn: deps,
+			Name:               cs.Name,
+			Path:               filepath.Join(r.basePath, cs.Path),
+			DependsOn:          deps,
+			HealthCheckTimeout: cs.HealthTimeout(),
+			AutoRollback:       cs.RollbackEnabled(),
 		})
 	}
 	return stacks
@@ -262,9 +369,11 @@ func (r *Reconciler) configToDeployStacks(configStacks []config.Stack) []deploy.
 	stacks := make([]deploy.Stack, len(configStacks))
 	for i, cs := range configStacks {
 		stacks[i] = deploy.Stack{
-			Name:      cs.Name,
-			Path:      filepath.Join(r.basePath, cs.Path),
-			DependsOn: cs.DependsOn,
+			Name:               cs.Name,
+			Path:               filepath.Join(r.basePath, cs.Path),
+			DependsOn:          cs.DependsOn,
+			HealthCheckTimeout: cs.HealthTimeout(),
+			AutoRollback:       cs.RollbackEnabled(),
 		}
 	}
 	return stacks
@@ -309,6 +418,35 @@ func (r *Reconciler) recordGitCommitMetric(ctx context.Context) {
 		otelmetric.WithAttributes(
 			attribute.String("host", r.hostname),
 			attribute.String("commit", r.poller.LastHash()),
+		),
+	)
+}
+
+func (r *Reconciler) markStackHealth(ctx context.Context, stackName string, healthy bool) {
+	if r.metrics == nil {
+		return
+	}
+	val := 0.0
+	if healthy {
+		val = 1.0
+	}
+	r.metrics.StackHealthy.Record(ctx, val,
+		otelmetric.WithAttributes(
+			attribute.String("host", r.hostname),
+			attribute.String("stack", stackName),
+		),
+	)
+}
+
+func (r *Reconciler) recordRollbackMetric(ctx context.Context, stackName, result string) {
+	if r.metrics == nil {
+		return
+	}
+	r.metrics.RollbackTotal.Add(ctx, 1,
+		otelmetric.WithAttributes(
+			attribute.String("host", r.hostname),
+			attribute.String("stack", stackName),
+			attribute.String("result", result),
 		),
 	)
 }

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -239,18 +240,25 @@ func (r *Reconciler) deployGroups(ctx context.Context, groups [][]deploy.Stack, 
 	for i, group := range groups {
 		// Use a plain errgroup (no context cancellation) so that a
 		// rollback in one stack doesn't cancel sibling deploys.
+		// ErrRolledBack is treated as a non-error inside the goroutine
+		// (tracked via atomic flag) so it doesn't mask real failures.
 		var g errgroup.Group
+		var groupRolledBack atomic.Bool
 		for _, stack := range group {
 			g.Go(func() error {
-				return r.deployStack(ctx, stack, commitHash)
+				err := r.deployStack(ctx, stack, commitHash)
+				if errors.Is(err, ErrRolledBack) {
+					groupRolledBack.Store(true)
+					return nil // don't mask real errors
+				}
+				return err
 			})
 		}
 		if err := g.Wait(); err != nil {
-			if errors.Is(err, ErrRolledBack) {
-				rolledBack = true
-				continue // stack is running (rolled back), proceed with downstream
-			}
 			return fmt.Errorf("group %d: %w", i+1, err)
+		}
+		if groupRolledBack.Load() {
+			rolledBack = true
 		}
 	}
 	if rolledBack {
@@ -275,7 +283,7 @@ func (r *Reconciler) deployStack(ctx context.Context, stack deploy.Stack, commit
 
 			if !stack.AutoRollback {
 				r.markStackHealth(ctx, stack.Name, false)
-				return fmt.Errorf("stack %q unhealthy, auto_rollback disabled", stack.Name)
+				return fmt.Errorf("stack %q unhealthy, auto_rollback disabled: %w", stack.Name, err)
 			}
 
 			return r.rollback(ctx, stack, commitHash)

--- a/internal/reconciler/reconciler_integration_test.go
+++ b/internal/reconciler/reconciler_integration_test.go
@@ -4,16 +4,23 @@ package reconciler
 
 import (
 	"context"
+	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/mohitsharma44/dockcd/internal/config"
+	"github.com/mohitsharma44/dockcd/internal/deploy"
 	"github.com/mohitsharma44/dockcd/internal/git"
 	"github.com/mohitsharma44/dockcd/internal/server"
 	"github.com/mohitsharma44/dockcd/internal/testutil"
 )
+
+func writeFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0644)
+}
 
 func TestIntegrationReconcileLoop(t *testing.T) {
 	// 1. Create bare repo (the "remote").
@@ -241,5 +248,274 @@ func TestIntegrationRunLoopWithInitialSync(t *testing.T) {
 	_, commit := status.Snapshot()
 	if commit == "" {
 		t.Error("expected status commit to be set after initial sync")
+	}
+}
+
+func TestIntegrationHealthyDeployRecordsSuccessfulCommit(t *testing.T) {
+	bareDir := testutil.InitBareRepo(t)
+	workDir := testutil.CloneAndSetup(t, bareDir)
+	goodHash := testutil.CommitFile(t, workDir, "stacks/web/compose.yaml",
+		"services:\n  web:\n    image: nginx", "add web stack")
+
+	cloneDir := filepath.Join(t.TempDir(), "dockcd-clone")
+	poller := git.NewPoller(bareDir, cloneDir)
+	poller.SetStateFile(filepath.Join(cloneDir, ".dockcd_state"))
+
+	var mu sync.Mutex
+	var calls []deployCall
+	runner := func(ctx context.Context, dir, name string, args ...string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, deployCall{dir: dir, name: name, args: args})
+		return nil
+	}
+
+	// Output runner that reports healthy containers.
+	outputRunner := func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+		return []byte(`{"Name":"web-1","State":"running","Health":""}` + "\n"), nil
+	}
+
+	status := &server.Status{}
+	rec, err := New(Config{
+		Poller:       poller,
+		HostStacks:   []config.Stack{{Name: "web", Path: "stacks/web"}},
+		Hostname:     "integration-test",
+		RepoDir:      cloneDir,
+		PollInterval: 100 * time.Millisecond,
+		Runner:       runner,
+		OutputRunner: outputRunner,
+		Status:       status,
+	})
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	if err := rec.initRepo(); err != nil {
+		t.Fatalf("initRepo failed: %v", err)
+	}
+
+	// Deploy the stack with health check.
+	stack := deploy.Stack{
+		Name:               "web",
+		Path:               "stacks/web",
+		HealthCheckTimeout: 5 * time.Second,
+		AutoRollback:       true,
+	}
+
+	if err := rec.deployStack(context.Background(), stack, goodHash); err != nil {
+		t.Fatalf("deployStack failed: %v", err)
+	}
+
+	// Verify lastSuccessfulCommit was recorded via the real poller's state.
+	if got := poller.LastSuccessfulCommit("web"); got != goodHash {
+		t.Errorf("expected lastSuccessfulCommit=%q, got %q", goodHash, got)
+	}
+}
+
+func TestIntegrationRollbackToLastGoodCommit(t *testing.T) {
+	bareDir := testutil.InitBareRepo(t)
+	workDir := testutil.CloneAndSetup(t, bareDir)
+
+	// Commit 1: "good" version.
+	goodHash := testutil.CommitFile(t, workDir, "stacks/web/compose.yaml",
+		"services:\n  web:\n    image: nginx:good", "good deploy")
+
+	// Commit 2: "bad" version.
+	testutil.CommitFile(t, workDir, "stacks/web/compose.yaml",
+		"services:\n  web:\n    image: nginx:bad", "bad deploy")
+
+	cloneDir := filepath.Join(t.TempDir(), "dockcd-clone")
+	poller := git.NewPoller(bareDir, cloneDir)
+	poller.SetStateFile(filepath.Join(cloneDir, ".dockcd_state"))
+
+	var mu sync.Mutex
+	var calls []deployCall
+	runner := func(ctx context.Context, dir, name string, args ...string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, deployCall{dir: dir, name: name, args: args})
+		return nil
+	}
+
+	// Output runner: always reports unhealthy (simulates bad deploy).
+	outputRunner := func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+		return []byte(`{"Name":"web-1","State":"exited","Health":""}` + "\n"), nil
+	}
+
+	status := &server.Status{}
+	rec, err := New(Config{
+		Poller:       poller,
+		HostStacks:   []config.Stack{{Name: "web", Path: "stacks/web"}},
+		Hostname:     "integration-test",
+		RepoDir:      cloneDir,
+		PollInterval: 100 * time.Millisecond,
+		Runner:       runner,
+		OutputRunner: outputRunner,
+		Status:       status,
+	})
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	if err := rec.initRepo(); err != nil {
+		t.Fatalf("initRepo failed: %v", err)
+	}
+
+	// Manually record the good commit as lastSuccessfulCommit (simulating a prior successful deploy).
+	if err := poller.SetLastSuccessfulCommit("web", goodHash); err != nil {
+		t.Fatalf("SetLastSuccessfulCommit failed: %v", err)
+	}
+
+	// Deploy the "bad" commit with health check that will fail.
+	badHash := poller.LastHash()
+	stack := deploy.Stack{
+		Name:               "web",
+		Path:               "stacks/web",
+		HealthCheckTimeout: 1 * time.Millisecond, // fail fast
+		AutoRollback:       true,
+	}
+
+	err = rec.deployStack(context.Background(), stack, badHash)
+	// Rollback should succeed — no error returned.
+	if err != nil {
+		t.Fatalf("deployStack should succeed after rollback, got: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Expect: initial deploy (pull+up) + rollback deploy (pull+up) = 4 calls.
+	if len(calls) != 4 {
+		t.Fatalf("expected 4 calls (deploy + rollback), got %d: %+v", len(calls), calls)
+	}
+
+	// The rollback deploy should be from a temp dir (not the repo clone dir).
+	rollbackPullDir := calls[2].dir
+	rollbackUpDir := calls[3].dir
+	if strings.HasPrefix(rollbackPullDir, cloneDir) {
+		t.Errorf("rollback should deploy from temp dir, not clone dir: %s", rollbackPullDir)
+	}
+	if rollbackPullDir != rollbackUpDir {
+		t.Errorf("rollback pull and up should use same dir: %s vs %s", rollbackPullDir, rollbackUpDir)
+	}
+
+	// lastSuccessfulCommit should still be the good hash (not updated to bad).
+	if got := poller.LastSuccessfulCommit("web"); got != goodHash {
+		t.Errorf("lastSuccessfulCommit should still be %q, got %q", goodHash, got)
+	}
+}
+
+func TestIntegrationNoHistoryNoRollback(t *testing.T) {
+	bareDir := testutil.InitBareRepo(t)
+	workDir := testutil.CloneAndSetup(t, bareDir)
+	testutil.CommitFile(t, workDir, "stacks/web/compose.yaml",
+		"services:\n  web:\n    image: nginx", "first deploy")
+
+	cloneDir := filepath.Join(t.TempDir(), "dockcd-clone")
+	poller := git.NewPoller(bareDir, cloneDir)
+	poller.SetStateFile(filepath.Join(cloneDir, ".dockcd_state"))
+
+	var mu sync.Mutex
+	var calls []deployCall
+	runner := func(ctx context.Context, dir, name string, args ...string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, deployCall{dir: dir, name: name, args: args})
+		return nil
+	}
+
+	outputRunner := func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+		return []byte(`{"Name":"web-1","State":"exited","Health":""}` + "\n"), nil
+	}
+
+	status := &server.Status{}
+	rec, err := New(Config{
+		Poller:       poller,
+		HostStacks:   []config.Stack{{Name: "web", Path: "stacks/web"}},
+		Hostname:     "integration-test",
+		RepoDir:      cloneDir,
+		PollInterval: 100 * time.Millisecond,
+		Runner:       runner,
+		OutputRunner: outputRunner,
+		Status:       status,
+	})
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	if err := rec.initRepo(); err != nil {
+		t.Fatalf("initRepo failed: %v", err)
+	}
+
+	// No lastSuccessfulCommit set — first deploy ever.
+	stack := deploy.Stack{
+		Name:               "web",
+		Path:               "stacks/web",
+		HealthCheckTimeout: 1 * time.Millisecond,
+		AutoRollback:       true,
+	}
+
+	err = rec.deployStack(context.Background(), stack, poller.LastHash())
+	if err == nil {
+		t.Fatal("expected error when no rollback history exists")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Should only have the initial deploy (pull+up), no rollback.
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls (deploy only), got %d", len(calls))
+	}
+}
+
+func TestIntegrationStateFileMigration(t *testing.T) {
+	bareDir := testutil.InitBareRepo(t)
+	workDir := testutil.CloneAndSetup(t, bareDir)
+	hash := testutil.CommitFile(t, workDir, "stacks/web/compose.yaml",
+		"services:\n  web:\n    image: nginx", "add web")
+
+	cloneDir := filepath.Join(t.TempDir(), "dockcd-clone")
+	stateFile := filepath.Join(cloneDir, ".dockcd_state")
+
+	// Create a legacy plain-text state file.
+	poller1 := git.NewPoller(bareDir, cloneDir)
+	if err := poller1.Clone(); err != nil {
+		t.Fatalf("Clone failed: %v", err)
+	}
+
+	// Write legacy format (just the hash).
+	if err := writeFile(stateFile, hash); err != nil {
+		t.Fatalf("writing legacy state: %v", err)
+	}
+
+	// New poller should load legacy format successfully.
+	poller2 := git.NewPoller(bareDir, cloneDir)
+	poller2.SetStateFile(stateFile)
+	if err := poller2.LoadState(); err != nil {
+		t.Fatalf("LoadState failed: %v", err)
+	}
+
+	if got := poller2.LastHash(); got != hash {
+		t.Errorf("expected LastHash=%q, got %q", hash, got)
+	}
+
+	// SetLastSuccessfulCommit should upgrade to JSON format.
+	if err := poller2.SetLastSuccessfulCommit("web", hash); err != nil {
+		t.Fatalf("SetLastSuccessfulCommit failed: %v", err)
+	}
+
+	// Load again — should read JSON format.
+	poller3 := git.NewPoller(bareDir, cloneDir)
+	poller3.SetStateFile(stateFile)
+	if err := poller3.LoadState(); err != nil {
+		t.Fatalf("LoadState (JSON) failed: %v", err)
+	}
+
+	if got := poller3.LastHash(); got != hash {
+		t.Errorf("expected LastHash=%q after JSON migration, got %q", hash, got)
+	}
+	if got := poller3.LastSuccessfulCommit("web"); got != hash {
+		t.Errorf("expected LastSuccessfulCommit(web)=%q, got %q", hash, got)
 	}
 }

--- a/internal/reconciler/reconciler_integration_test.go
+++ b/internal/reconciler/reconciler_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -92,7 +93,7 @@ func TestIntegrationReconcileLoop(t *testing.T) {
 	mu.Lock()
 	var upDirs []string
 	for _, c := range calls {
-		if len(c.args) > 1 && c.args[0] == "compose" && c.args[1] == "up" {
+		if c.args[0] == "compose" && slices.Contains(c.args, "up") {
 			upDirs = append(upDirs, c.dir)
 		}
 	}

--- a/internal/reconciler/reconciler_integration_test.go
+++ b/internal/reconciler/reconciler_integration_test.go
@@ -93,7 +93,7 @@ func TestIntegrationReconcileLoop(t *testing.T) {
 	mu.Lock()
 	var upDirs []string
 	for _, c := range calls {
-		if c.args[0] == "compose" && slices.Contains(c.args, "up") {
+		if len(c.args) > 0 && c.args[0] == "compose" && slices.Contains(c.args, "up") {
 			upDirs = append(upDirs, c.dir)
 		}
 	}

--- a/internal/reconciler/reconciler_integration_test.go
+++ b/internal/reconciler/reconciler_integration_test.go
@@ -4,6 +4,7 @@ package reconciler
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -376,9 +377,9 @@ func TestIntegrationRollbackToLastGoodCommit(t *testing.T) {
 	}
 
 	err = rec.deployStack(context.Background(), stack, badHash)
-	// Rollback should succeed — no error returned.
-	if err != nil {
-		t.Fatalf("deployStack should succeed after rollback, got: %v", err)
+	// Rollback should succeed — returns ErrRolledBack.
+	if !errors.Is(err, ErrRolledBack) {
+		t.Fatalf("expected ErrRolledBack, got: %v", err)
 	}
 
 	mu.Lock()

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -479,7 +479,7 @@ func TestDeployOrderRespectsDependencies(t *testing.T) {
 	var order []string
 	runner := func(ctx context.Context, dir, name string, args ...string) error {
 		// Only track "compose up" calls, not "compose pull".
-		if args[0] == "compose" && slices.Contains(args, "up") {
+		if len(args) > 0 && args[0] == "compose" && slices.Contains(args, "up") {
 			mu.Lock()
 			order = append(order, dir)
 			mu.Unlock()

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -2,13 +2,16 @@ package reconciler
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/mohitsharma44/dockcd/internal/config"
+	"github.com/mohitsharma44/dockcd/internal/deploy"
 	"github.com/mohitsharma44/dockcd/internal/server"
 )
 
@@ -22,9 +25,13 @@ type mockPoller struct {
 	changedErr    error
 	lastHash      string
 
-	cloneCalled bool
-	fetchCalled bool
-	loadCalled  bool
+	cloneCalled          bool
+	fetchCalled          bool
+	loadCalled           bool
+	lastSuccessful       map[string]string
+	extractErr           error
+	extractedFiles       map[string]string // path -> content (for rollback tests)
+	setSuccessfulCalled  map[string]string // stack -> hash
 }
 
 func (m *mockPoller) Clone() error {
@@ -47,6 +54,40 @@ func (m *mockPoller) LastHash() string {
 
 func (m *mockPoller) LoadState() error {
 	m.loadCalled = true
+	return nil
+}
+
+func (m *mockPoller) LastSuccessfulCommit(stack string) string {
+	if m.lastSuccessful == nil {
+		return ""
+	}
+	return m.lastSuccessful[stack]
+}
+
+func (m *mockPoller) SetLastSuccessfulCommit(stack, hash string) error {
+	if m.setSuccessfulCalled == nil {
+		m.setSuccessfulCalled = make(map[string]string)
+	}
+	m.setSuccessfulCalled[stack] = hash
+	return nil
+}
+
+func (m *mockPoller) ExtractAtCommit(commit, pathPrefix, destDir string) error {
+	if m.extractErr != nil {
+		return m.extractErr
+	}
+	// Write any configured files to destDir for rollback tests.
+	if m.extractedFiles != nil {
+		for path, content := range m.extractedFiles {
+			fullPath := filepath.Join(destDir, path)
+			if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+				return err
+			}
+			if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 
@@ -492,5 +533,195 @@ func TestFilterChangedStacksReturnsCorrectSet(t *testing.T) {
 
 	if len(names) != 2 || names[0] != "a" || names[1] != "c" {
 		t.Errorf("expected [a, c], got %v", names)
+	}
+}
+
+// --- Health check and rollback tests ---
+
+func TestDeployStackHealthyUpdatesSuccessfulCommit(t *testing.T) {
+	poller := &mockPoller{lastHash: "abc123"}
+	var mu sync.Mutex
+	var calls []deployCall
+	r, _ := testReconciler(t, poller, nil, mockRunner(&mu, &calls))
+
+	// Set up an output runner that reports healthy containers.
+	r.outputRunner = func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+		return []byte(`{"Name":"web-1","State":"running","Health":"healthy"}` + "\n"), nil
+	}
+
+	stack := deploy.Stack{
+		Name:               "web",
+		Path:               "docker/stacks/web",
+		HealthCheckTimeout: 10 * time.Second,
+		AutoRollback:       true,
+	}
+
+	err := r.deployStack(context.Background(), stack, "abc123")
+	if err != nil {
+		t.Fatalf("deployStack failed: %v", err)
+	}
+
+	// Should have recorded successful commit.
+	if poller.setSuccessfulCalled["web"] != "abc123" {
+		t.Errorf("expected SetLastSuccessfulCommit(web, abc123), got %v", poller.setSuccessfulCalled)
+	}
+}
+
+func TestDeployStackUnhealthyTriggersRollback(t *testing.T) {
+	poller := &mockPoller{
+		lastHash:       "bad456",
+		lastSuccessful: map[string]string{"web": "good123"},
+		extractedFiles: map[string]string{"compose.yaml": "services:\n  web:\n    image: nginx:old"},
+	}
+	var mu sync.Mutex
+	var calls []deployCall
+	r, _ := testReconciler(t, poller, nil, mockRunner(&mu, &calls))
+
+	// Output runner: first call (health check after deploy) returns unhealthy,
+	// triggering rollback.
+	r.outputRunner = func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+		return []byte(`{"Name":"web-1","State":"exited","Health":""}` + "\n"), nil
+	}
+
+	stack := deploy.Stack{
+		Name:               "web",
+		Path:               "docker/stacks/web",
+		HealthCheckTimeout: 1 * time.Millisecond, // very short to trigger timeout fast
+		AutoRollback:       true,
+	}
+
+	err := r.deployStack(context.Background(), stack, "bad456")
+	// Should succeed (rollback completed) — err is nil when rollback works.
+	if err != nil {
+		t.Fatalf("deployStack should succeed after rollback, got: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Should have: deploy pull + deploy up + rollback pull + rollback up = 4 calls.
+	if len(calls) != 4 {
+		t.Fatalf("expected 4 calls (deploy + rollback), got %d: %+v", len(calls), calls)
+	}
+
+	// Should NOT have updated successful commit (rollback means the new commit is bad).
+	if _, ok := poller.setSuccessfulCalled["web"]; ok {
+		t.Error("should not update successful commit after rollback")
+	}
+}
+
+func TestDeployStackNoHistoryNoRollback(t *testing.T) {
+	poller := &mockPoller{
+		lastHash:       "first123",
+		lastSuccessful: map[string]string{}, // no history
+	}
+	var mu sync.Mutex
+	var calls []deployCall
+	r, _ := testReconciler(t, poller, nil, mockRunner(&mu, &calls))
+
+	r.outputRunner = func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+		return []byte(`{"Name":"web-1","State":"exited","Health":""}` + "\n"), nil
+	}
+
+	stack := deploy.Stack{
+		Name:               "web",
+		Path:               "docker/stacks/web",
+		HealthCheckTimeout: 1 * time.Millisecond,
+		AutoRollback:       true,
+	}
+
+	err := r.deployStack(context.Background(), stack, "first123")
+	if err == nil {
+		t.Fatal("expected error when no rollback history exists")
+	}
+}
+
+func TestDeployStackRollbackDisabled(t *testing.T) {
+	poller := &mockPoller{
+		lastHash:       "bad456",
+		lastSuccessful: map[string]string{"web": "good123"},
+	}
+	var mu sync.Mutex
+	var calls []deployCall
+	r, _ := testReconciler(t, poller, nil, mockRunner(&mu, &calls))
+
+	r.outputRunner = func(ctx context.Context, dir, name string, args ...string) ([]byte, error) {
+		return []byte(`{"Name":"web-1","State":"exited","Health":""}` + "\n"), nil
+	}
+
+	stack := deploy.Stack{
+		Name:               "web",
+		Path:               "docker/stacks/web",
+		HealthCheckTimeout: 1 * time.Millisecond,
+		AutoRollback:       false, // disabled
+	}
+
+	err := r.deployStack(context.Background(), stack, "bad456")
+	if err == nil {
+		t.Fatal("expected error when rollback is disabled")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Should only have the initial deploy (2 calls), no rollback.
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls (deploy only), got %d", len(calls))
+	}
+}
+
+func TestDeployStackNoHealthCheckSkipsCheck(t *testing.T) {
+	poller := &mockPoller{lastHash: "abc123"}
+	var mu sync.Mutex
+	var calls []deployCall
+	r, _ := testReconciler(t, poller, nil, mockRunner(&mu, &calls))
+
+	// No output runner set — health check should be skipped.
+	stack := deploy.Stack{
+		Name:               "web",
+		Path:               "docker/stacks/web",
+		HealthCheckTimeout: 60 * time.Second,
+		AutoRollback:       true,
+	}
+
+	err := r.deployStack(context.Background(), stack, "abc123")
+	if err != nil {
+		t.Fatalf("deployStack failed: %v", err)
+	}
+
+	// Should still record successful commit.
+	if poller.setSuccessfulCalled["web"] != "abc123" {
+		t.Errorf("expected SetLastSuccessfulCommit(web, abc123), got %v", poller.setSuccessfulCalled)
+	}
+}
+
+func TestDeployStackDeployFailureNoRollback(t *testing.T) {
+	poller := &mockPoller{
+		lastHash:       "abc123",
+		lastSuccessful: map[string]string{"web": "old123"},
+	}
+
+	// Runner that fails on compose pull.
+	failRunner := func(ctx context.Context, dir, name string, args ...string) error {
+		return fmt.Errorf("compose pull failed")
+	}
+
+	r, _ := testReconciler(t, poller, nil, failRunner)
+
+	stack := deploy.Stack{
+		Name:               "web",
+		Path:               "docker/stacks/web",
+		HealthCheckTimeout: 60 * time.Second,
+		AutoRollback:       true,
+	}
+
+	err := r.deployStack(context.Background(), stack, "abc123")
+	if err == nil {
+		t.Fatal("expected error from failed deploy")
+	}
+
+	// Should NOT have attempted rollback (deploy itself failed).
+	if _, ok := poller.setSuccessfulCalled["web"]; ok {
+		t.Error("should not update successful commit after deploy failure")
 	}
 }

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -2,6 +2,7 @@ package reconciler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -591,9 +592,9 @@ func TestDeployStackUnhealthyTriggersRollback(t *testing.T) {
 	}
 
 	err := r.deployStack(context.Background(), stack, "bad456")
-	// Should succeed (rollback completed) — err is nil when rollback works.
-	if err != nil {
-		t.Fatalf("deployStack should succeed after rollback, got: %v", err)
+	// Rollback succeeded — should return ErrRolledBack.
+	if !errors.Is(err, ErrRolledBack) {
+		t.Fatalf("expected ErrRolledBack, got: %v", err)
 	}
 
 	mu.Lock()

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"sync"
 	"testing"
@@ -478,7 +479,7 @@ func TestDeployOrderRespectsDependencies(t *testing.T) {
 	var order []string
 	runner := func(ctx context.Context, dir, name string, args ...string) error {
 		// Only track "compose up" calls, not "compose pull".
-		if len(args) > 0 && args[0] == "compose" && len(args) > 1 && args[1] == "up" {
+		if args[0] == "compose" && slices.Contains(args, "up") {
 			mu.Lock()
 			order = append(order, dir)
 			mu.Unlock()

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -32,6 +32,7 @@ type mockPoller struct {
 	lastSuccessful       map[string]string
 	extractErr           error
 	extractedFiles       map[string]string // path -> content (for rollback tests)
+	mu                   sync.Mutex
 	setSuccessfulCalled  map[string]string // stack -> hash
 }
 
@@ -59,6 +60,8 @@ func (m *mockPoller) LoadState() error {
 }
 
 func (m *mockPoller) LastSuccessfulCommit(stack string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.lastSuccessful == nil {
 		return ""
 	}
@@ -66,6 +69,8 @@ func (m *mockPoller) LastSuccessfulCommit(stack string) string {
 }
 
 func (m *mockPoller) SetLastSuccessfulCommit(stack, hash string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.setSuccessfulCalled == nil {
 		m.setSuccessfulCalled = make(map[string]string)
 	}


### PR DESCRIPTION
## Summary
- **Health checks**: After `docker compose up -d`, polls `docker compose ps --format json` to verify all containers are running/healthy. Configurable timeout per stack (default 60s).
- **Auto-rollback**: On health check failure, extracts the last known good compose files via `git show` to a temp dir and redeploys from there. Stack is marked degraded (`dockcd_stack_healthy=0`).
- **Per-stack state**: State file migrated from plain text to JSON with backward compatibility. Tracks `lastSuccessfulCommit` per stack.
- **Config additions**: `health_check_timeout` and `auto_rollback` per stack in gitops.yaml
- **Edge cases**: No history = no rollback (just mark failed). Rollback failure = mark degraded, retry on next commit.

Closes #6

## Test plan
- [x] `go test ./...` — all unit tests pass (including 6 new rollback tests)
- [x] `go test -tags integration ./internal/reconciler/` — integration tests pass
- [x] `go vet ./...` — clean
- [x] `go build ./...` — builds successfully
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)