### PR TITLE
Phase 2 Plan 1: Hooks, CLI/API, force-deploy, suspend/resume

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,3 +25,5 @@ jobs:
         run: go test -tags integration -race -v ./internal/reconciler/
       - name: Build
         run: go build ./cmd/dockcd/
+      - name: Docker build
+        run: docker build -t dockcd:ci .

--- a/cmd/dockcd/get.go
+++ b/cmd/dockcd/get.go
@@ -1,0 +1,8 @@
+package main
+
+import "fmt"
+
+func runGet(args []string) int {
+	fmt.Println("not implemented: get")
+	return 1
+}

--- a/cmd/dockcd/get.go
+++ b/cmd/dockcd/get.go
@@ -1,8 +1,78 @@
 package main
 
-import "fmt"
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/mohitsharma44/dockcd/internal/client"
+	"github.com/mohitsharma44/dockcd/internal/server"
+)
 
 func runGet(args []string) int {
-	fmt.Println("not implemented: get")
-	return 1
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "Usage: dockcd get <stacks|stack <name>> [flags]")
+		return 2
+	}
+	switch args[0] {
+	case "stacks":
+		return runGetStacks(args[1:])
+	case "stack":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "Usage: dockcd get stack <name> [flags]")
+			return 2
+		}
+		return runGetStack(args[1], args[2:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown resource: %s\nUsage: dockcd get <stacks|stack <name>>\n", args[0])
+		return 2
+	}
+}
+
+func runGetStacks(args []string) int {
+	fs := flag.NewFlagSet("get stacks", flag.ExitOnError)
+	outputFmt := fs.String("output", "table", "output format: table or json")
+	watch := fs.Bool("watch", false, "poll and refresh every 2 seconds")
+	srv := fs.String("server", resolveServerURL(nil), "dockcd server URL")
+	fs.Parse(args) //nolint:errcheck // ExitOnError handles errors
+
+	c := client.New(*srv)
+	for {
+		stacks, err := c.GetStacks()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return 1
+		}
+		if *outputFmt == "json" {
+			printJSON(stacks)
+		} else {
+			printStacksTable(stacks)
+		}
+		if !*watch {
+			return 0
+		}
+		time.Sleep(2 * time.Second)
+		fmt.Print("\033[2J\033[H") // clear screen
+	}
+}
+
+func runGetStack(name string, args []string) int {
+	fs := flag.NewFlagSet("get stack", flag.ExitOnError)
+	outputFmt := fs.String("output", "table", "output format: table or json")
+	srv := fs.String("server", resolveServerURL(nil), "dockcd server URL")
+	fs.Parse(args) //nolint:errcheck // ExitOnError handles errors
+
+	c := client.New(*srv)
+	stack, err := c.GetStack(name)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	if *outputFmt == "json" {
+		printJSON(stack)
+	} else {
+		printStacksTable([]server.StackState{*stack})
+	}
+	return 0
 }

--- a/cmd/dockcd/logs.go
+++ b/cmd/dockcd/logs.go
@@ -1,0 +1,8 @@
+package main
+
+import "fmt"
+
+func runLogs(args []string) int {
+	fmt.Println("not implemented: logs")
+	return 1
+}

--- a/cmd/dockcd/logs.go
+++ b/cmd/dockcd/logs.go
@@ -1,8 +1,46 @@
 package main
 
-import "fmt"
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+)
 
 func runLogs(args []string) int {
-	fmt.Println("not implemented: logs")
-	return 1
+	fs := flag.NewFlagSet("logs", flag.ExitOnError)
+	srv := fs.String("server", resolveServerURL(nil), "dockcd server URL")
+	fs.Parse(args) //nolint:errcheck // ExitOnError handles errors
+
+	resp, err := http.Get(*srv + "/api/v1/logs")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	defer resp.Body.Close()
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt)
+	defer signal.Stop(sig)
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		select {
+		case <-sig:
+			return 0
+		default:
+		}
+		line := scanner.Text()
+		if strings.HasPrefix(line, "data:") {
+			fmt.Println(strings.TrimPrefix(line, "data:"))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "error reading log stream: %v\n", err)
+		return 1
+	}
+	return 0
 }

--- a/cmd/dockcd/main.go
+++ b/cmd/dockcd/main.go
@@ -1,289 +1,57 @@
 package main
 
 import (
-	"context"
-	"errors"
-	"flag"
 	"fmt"
-	"log/slog"
-	"net/http"
 	"os"
-	"os/exec"
-	"os/signal"
-	"path/filepath"
-	"strconv"
-	"syscall"
-	"time"
-
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
-	"go.opentelemetry.io/otel/sdk/resource"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
-	"go.opentelemetry.io/otel/trace/noop"
-
-	"github.com/mohitsharma44/dockcd/internal/config"
-	"github.com/mohitsharma44/dockcd/internal/git"
-	"github.com/mohitsharma44/dockcd/internal/metrics"
-	"github.com/mohitsharma44/dockcd/internal/reconciler"
-	"github.com/mohitsharma44/dockcd/internal/server"
 )
 
-// tracerShutdown is implemented by both sdktrace.TracerProvider and noopShutdown.
-type tracerShutdown interface {
-	Shutdown(ctx context.Context) error
-}
-
-// noopShutdown wraps a noop TracerProvider with a no-op Shutdown method.
-type noopShutdown struct{}
-
-func (noopShutdown) Shutdown(context.Context) error { return nil }
-
-// setupTracing creates an OTel TracerProvider. If DOCKCD_OTEL_ENDPOINT is set,
-// traces are exported via OTLP gRPC (e.g. to Alloy → Tempo). If unset, a true
-// no-op provider is used (zero overhead).
-func setupTracing(ctx context.Context, logger *slog.Logger) (tracerShutdown, error) {
-	endpoint := os.Getenv("DOCKCD_OTEL_ENDPOINT")
-
-	// No endpoint configured — use a true no-op TracerProvider (zero overhead).
-	if endpoint == "" {
-		logger.Info("tracing disabled (DOCKCD_OTEL_ENDPOINT not set)")
-		otel.SetTracerProvider(noop.NewTracerProvider())
-		return noopShutdown{}, nil
-	}
-
-	// Create OTLP gRPC exporter pointing at the configured endpoint.
-	// WithInsecure() because internal networks (Alloy) typically don't use TLS.
-	exporter, err := otlptracegrpc.New(ctx,
-		otlptracegrpc.WithEndpoint(endpoint),
-		otlptracegrpc.WithInsecure(),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("creating OTLP trace exporter: %w", err)
-	}
-
-	// Resource describes "who is sending these traces" — like adding
-	// service.name and service.version tags to every span.
-	res, err := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceName("dockcd"),
-		),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("creating trace resource: %w", err)
-	}
-
-	tp := sdktrace.NewTracerProvider(
-		sdktrace.WithBatcher(exporter),
-		sdktrace.WithResource(res),
-	)
-	otel.SetTracerProvider(tp)
-
-	logger.Info("tracing enabled", "endpoint", endpoint)
-	return tp, nil
-}
-
-// execCommand runs a shell command in the given directory.
-// Used as the production deploy.CommandRunner.
-func execCommand(ctx context.Context, dir string, name string, args ...string) error {
-	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Dir = dir
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("%s %v: %w\n%s", name, args, err, out)
-	}
-	return nil
-}
-
-// execCommandOutput runs a shell command and returns its output.
-// Used as the production deploy.OutputRunner for health checks.
-func execCommandOutput(ctx context.Context, dir string, name string, args ...string) ([]byte, error) {
-	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Dir = dir
-	return cmd.CombinedOutput()
-}
+// Version is set at build time via -ldflags.
+var Version = "dev"
 
 func main() {
-	configPath := flag.String("config", "gitops.yaml", "path to gitops config file")
-	host := flag.String("host", "", "host name (overrides DOCKCD_HOST env and hostname)")
-	logFormat := flag.String("log-format", "text", "log format: text or json")
-	metricsPort := flag.Int("metrics-port", 0, "port for metrics and health HTTP server (default 9092, or DOCKCD_METRICS_PORT)")
-	repoDir := flag.String("repo-dir", "", "local git clone path (default /opt/dockcd/repo, or DOCKCD_REPO_DIR)")
-	pollInterval := flag.Duration("poll-interval", 0, "git poll interval (default 30s, or DOCKCD_POLL_INTERVAL)")
-	initialSync := flag.Bool("initial-sync", false, "deploy all stacks on first run (or DOCKCD_INITIAL_SYNC=true)")
-	flag.Parse()
-
-	// Resolve metrics port: flag > env var > default 9092.
-	if *metricsPort == 0 {
-		if envPort := os.Getenv("DOCKCD_METRICS_PORT"); envPort != "" {
-			p, err := strconv.Atoi(envPort)
-			if err != nil {
-				slog.Error("invalid DOCKCD_METRICS_PORT", "value", envPort, "error", err)
-				os.Exit(1)
-			}
-			*metricsPort = p
-		} else {
-			*metricsPort = 9092
-		}
+	if len(os.Args) < 2 {
+		// No subcommand — default to serve (backward compat).
+		os.Exit(runServe(os.Args[1:]))
 	}
 
-	// Resolve repo dir: flag > env var > default.
-	if *repoDir == "" {
-		if envDir := os.Getenv("DOCKCD_REPO_DIR"); envDir != "" {
-			*repoDir = envDir
-		} else {
-			*repoDir = "/opt/dockcd/repo"
-		}
-	}
-
-	// Resolve poll interval: flag > env var > default 30s.
-	if *pollInterval == 0 {
-		if envInterval := os.Getenv("DOCKCD_POLL_INTERVAL"); envInterval != "" {
-			d, err := time.ParseDuration(envInterval)
-			if err != nil {
-				slog.Error("invalid DOCKCD_POLL_INTERVAL", "value", envInterval, "error", err)
-				os.Exit(1)
-			}
-			*pollInterval = d
-		} else {
-			*pollInterval = 30 * time.Second
-		}
-	}
-
-	// Resolve initial sync: flag > env var.
-	if !*initialSync {
-		*initialSync = os.Getenv("DOCKCD_INITIAL_SYNC") == "true"
-	}
-
-	// Setup logger
-	var handler slog.Handler
-	switch *logFormat {
-	case "json":
-		handler = slog.NewJSONHandler(os.Stdout, nil)
+	switch os.Args[1] {
+	case "serve":
+		os.Exit(runServe(os.Args[2:]))
+	case "version":
+		os.Exit(runVersion(os.Args[2:]))
+	case "get":
+		os.Exit(runGet(os.Args[2:]))
+	case "reconcile":
+		os.Exit(runReconcile(os.Args[2:]))
+	case "suspend":
+		os.Exit(runSuspend(os.Args[2:]))
+	case "resume":
+		os.Exit(runResume(os.Args[2:]))
+	case "logs":
+		os.Exit(runLogs(os.Args[2:]))
+	case "stats":
+		os.Exit(runStats(os.Args[2:]))
 	default:
-		handler = slog.NewTextHandler(os.Stdout, nil)
-	}
-	logger := slog.New(handler)
-
-	// Load config
-	cfg, err := config.Load(*configPath)
-	if err != nil {
-		logger.Error("failed to load config", "error", err)
-		os.Exit(1)
-	}
-
-	// Resolve hostname
-	hostname := *host
-	if hostname == "" {
-		hostname = os.Getenv("DOCKCD_HOST")
-	}
-	if hostname == "" {
-		hostname, err = os.Hostname()
-		if err != nil {
-			logger.Error("failed to get hostname", "error", err)
-			os.Exit(1)
+		// Check if it looks like a flag — treat as serve for backward compat.
+		if len(os.Args[1]) > 0 && os.Args[1][0] == '-' {
+			os.Exit(runServe(os.Args[1:]))
 		}
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
+		printUsage()
+		os.Exit(2)
 	}
+}
 
-	// Verify host exists in config
-	hostCfg, ok := cfg.Hosts[hostname]
-	if !ok {
-		logger.Error("host not found in config", "host", hostname)
-		os.Exit(1)
-	}
+func printUsage() {
+	fmt.Fprintln(os.Stderr, `Usage: dockcd <command> [flags]
 
-	// Setup metrics — creates OTel MeterProvider backed by Prometheus exporter.
-	meterProvider, err := metrics.Setup()
-	if err != nil {
-		logger.Error("failed to setup metrics", "error", err)
-		os.Exit(1)
-	}
-
-	meter := meterProvider.Meter("dockcd")
-	m, err := metrics.New(meter)
-	if err != nil {
-		logger.Error("failed to create metrics", "error", err)
-		os.Exit(1)
-	}
-
-	// Setup tracing — exports spans via OTLP gRPC if DOCKCD_OTEL_ENDPOINT is set.
-	// If unset, tracing is a no-op (zero overhead).
-	tracerProvider, err := setupTracing(context.Background(), logger)
-	if err != nil {
-		logger.Error("failed to setup tracing", "error", err)
-		os.Exit(1)
-	}
-
-	// Setup HTTP server for /metrics and /healthz.
-	status := &server.Status{}
-	srv := server.New(fmt.Sprintf(":%d", *metricsPort), status, logger)
-
-	// Create git poller and reconciler.
-	poller := git.NewPoller(cfg.Repo, *repoDir)
-	poller.SetStateFile(filepath.Join(*repoDir, ".dockcd_state"))
-
-	rec, err := reconciler.New(reconciler.Config{
-		Poller:       poller,
-		HostStacks:   hostCfg.Stacks,
-		Hostname:     hostname,
-		BasePath:     cfg.BasePath,
-		RepoDir:      *repoDir,
-		PollInterval: *pollInterval,
-		InitialSync:  *initialSync,
-		Runner:       execCommand,
-		OutputRunner: execCommandOutput,
-		Metrics:      m,
-		Status:       status,
-		Logger:       logger,
-	})
-	if err != nil {
-		logger.Error("failed to create reconciler", "error", err)
-		os.Exit(1)
-	}
-
-	// Start HTTP server in a goroutine (non-blocking).
-	go func() {
-		logger.Info("http server starting", "port", *metricsPort)
-		if err := srv.Start(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			logger.Error("http server failed", "error", err)
-		}
-	}()
-
-	// Setup signal handling
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer cancel()
-
-	logger.Info("dockcd starting",
-		"host", hostname,
-		"repo", cfg.Repo,
-		"stacks", len(hostCfg.Stacks),
-		"poll_interval", *pollInterval,
-		"initial_sync", *initialSync,
-	)
-
-	// Run the reconcile loop — blocks until context is cancelled.
-	if err := rec.Run(ctx); err != nil {
-		logger.Error("reconciler failed", "error", err)
-		// Non-zero exit so systemd/k8s can detect the failure.
-		defer os.Exit(1)
-	}
-	logger.Info("shutting down")
-
-	// Graceful shutdown: stop HTTP server, then flush metrics.
-	// context.Background() here because the signal context is already cancelled.
-	shutdownCtx := context.Background()
-
-	if err := srv.Shutdown(shutdownCtx); err != nil {
-		logger.Error("http server shutdown failed", "error", err)
-	}
-
-	if err := meterProvider.Shutdown(shutdownCtx); err != nil {
-		logger.Error("meter provider shutdown failed", "error", err)
-	}
-
-	if err := tracerProvider.Shutdown(shutdownCtx); err != nil {
-		logger.Error("tracer provider shutdown failed", "error", err)
-	}
+Commands:
+  serve       Start the dockcd daemon (default if no command given)
+  get         Get stack status (get stacks | get stack <name>)
+  reconcile   Trigger reconciliation (reconcile stacks | reconcile stack <name>)
+  suspend     Suspend a stack (suspend stack <name>)
+  resume      Resume a stack (resume stack <name>)
+  logs        Stream server logs
+  stats       Show metrics summary
+  version     Show client and server version`)
 }

--- a/cmd/dockcd/output.go
+++ b/cmd/dockcd/output.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"os"
+	"strings"
+)
+
+// resolveServerURL extracts --server flag or falls back to env/default.
+func resolveServerURL(args []string) string {
+	for i, arg := range args {
+		if arg == "--server" && i+1 < len(args) {
+			return args[i+1]
+		}
+		if strings.HasPrefix(arg, "--server=") {
+			return strings.TrimPrefix(arg, "--server=")
+		}
+	}
+	if url := os.Getenv("DOCKCD_SERVER"); url != "" {
+		return url
+	}
+	return "http://localhost:9092"
+}

--- a/cmd/dockcd/output.go
+++ b/cmd/dockcd/output.go
@@ -1,8 +1,13 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"strings"
+	"text/tabwriter"
+
+	"github.com/mohitsharma44/dockcd/internal/server"
 )
 
 // resolveServerURL extracts --server flag or falls back to env/default.
@@ -19,4 +24,64 @@ func resolveServerURL(args []string) string {
 		return url
 	}
 	return "http://localhost:9092"
+}
+
+// useColor reports whether terminal color output should be used.
+// Color is disabled when the NO_COLOR environment variable is set.
+func useColor() bool {
+	return os.Getenv("NO_COLOR") == ""
+}
+
+// colorize wraps s in the given ANSI escape code when color is enabled.
+func colorize(s, code string) string {
+	if !useColor() {
+		return s
+	}
+	return code + s + "\033[0m"
+}
+
+// statusIcon returns a colored Unicode icon for the given stack status.
+func statusIcon(status string) string {
+	switch status {
+	case "Ready":
+		return colorize("✓", "\033[32m")
+	case "Failed":
+		return colorize("✗", "\033[31m")
+	case "Suspended":
+		return colorize("⏸", "\033[33m")
+	case "Reconciling":
+		return colorize("↻", "\033[34m")
+	default:
+		return " "
+	}
+}
+
+// printStacksTable writes a human-readable table of stacks to stdout.
+func printStacksTable(stacks []server.StackState) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "NAME\tBRANCH\tSTATUS\tHEALTH\tLAST DEPLOY\tCOMMIT")
+	for _, s := range stacks {
+		lastDeploy := "--"
+		if !s.LastDeploy.IsZero() {
+			lastDeploy = s.LastDeploy.Format("2006-01-02 15:04:05")
+		}
+		commit := s.Commit
+		if len(commit) > 7 {
+			commit = commit[:7]
+		}
+		health := s.Health
+		if health == "" {
+			health = "--"
+		}
+		fmt.Fprintf(w, "%s %s\t%s\t%s\t%s\t%s\t%s\n",
+			statusIcon(s.Status), s.Name, s.Branch, s.Status, health, lastDeploy, commit)
+	}
+	w.Flush()
+}
+
+// printJSON writes v to stdout as indented JSON.
+func printJSON(v any) {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	enc.Encode(v)
 }

--- a/cmd/dockcd/reconcile.go
+++ b/cmd/dockcd/reconcile.go
@@ -1,0 +1,8 @@
+package main
+
+import "fmt"
+
+func runReconcile(args []string) int {
+	fmt.Println("not implemented: reconcile")
+	return 1
+}

--- a/cmd/dockcd/reconcile.go
+++ b/cmd/dockcd/reconcile.go
@@ -1,8 +1,74 @@
 package main
 
-import "fmt"
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/mohitsharma44/dockcd/internal/client"
+)
 
 func runReconcile(args []string) int {
-	fmt.Println("not implemented: reconcile")
-	return 1
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "Usage: dockcd reconcile <stacks|stack <name>> [flags]")
+		return 2
+	}
+	switch args[0] {
+	case "stacks":
+		return runReconcileAll(args[1:])
+	case "stack":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "Usage: dockcd reconcile stack <name> [flags]")
+			return 2
+		}
+		return runReconcileStack(args[1], args[2:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown resource: %s\nUsage: dockcd reconcile <stacks|stack <name>>\n", args[0])
+		return 2
+	}
+}
+
+func runReconcileStack(name string, args []string) int {
+	fs := flag.NewFlagSet("reconcile stack", flag.ExitOnError)
+	noWait := fs.Bool("no-wait", false, "return immediately without waiting")
+	srv := fs.String("server", resolveServerURL(nil), "dockcd server URL")
+	fs.Parse(args) //nolint:errcheck // ExitOnError handles errors
+
+	c := client.New(*srv)
+	resp, err := c.Reconcile(name)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	fmt.Printf("%s triggering reconciliation for stack %s\n", colorize("►", "\033[34m"), name)
+	if *noWait {
+		fmt.Printf("reconcile queued: %s\n", resp.ID)
+		return 0
+	}
+	// SSE streaming will be added in a future iteration.
+	fmt.Printf("reconcile started: %s (use 'dockcd get stack %s' to check status)\n", resp.ID, name)
+	return 0
+}
+
+func runReconcileAll(args []string) int {
+	fs := flag.NewFlagSet("reconcile stacks", flag.ExitOnError)
+	noWait := fs.Bool("no-wait", false, "return immediately")
+	srv := fs.String("server", resolveServerURL(nil), "dockcd server URL")
+	fs.Parse(args) //nolint:errcheck // ExitOnError handles errors
+
+	c := client.New(*srv)
+	resp, err := c.ReconcileAll()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	fmt.Printf("%s triggering reconciliation for all stacks\n", colorize("►", "\033[34m"))
+	if *noWait {
+		fmt.Printf("reconcile queued: %s\n", resp.ID)
+		return 0
+	}
+	fmt.Printf("reconcile started: %s\n", resp.ID)
+	return 0
 }

--- a/cmd/dockcd/resume.go
+++ b/cmd/dockcd/resume.go
@@ -1,0 +1,8 @@
+package main
+
+import "fmt"
+
+func runResume(args []string) int {
+	fmt.Println("not implemented: resume")
+	return 1
+}

--- a/cmd/dockcd/resume.go
+++ b/cmd/dockcd/resume.go
@@ -1,8 +1,29 @@
 package main
 
-import "fmt"
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/mohitsharma44/dockcd/internal/client"
+)
 
 func runResume(args []string) int {
-	fmt.Println("not implemented: resume")
-	return 1
+	if len(args) < 2 || args[0] != "stack" {
+		fmt.Fprintln(os.Stderr, "Usage: dockcd resume stack <name> [flags]")
+		return 2
+	}
+	name := args[1]
+	fs := flag.NewFlagSet("resume", flag.ExitOnError)
+	srv := fs.String("server", resolveServerURL(nil), "dockcd server URL")
+	fs.Parse(args[2:]) //nolint:errcheck // ExitOnError handles errors
+
+	c := client.New(*srv)
+	stack, err := c.Resume(name)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	fmt.Printf("%s stack %q resumed\n", colorize("✓", "\033[32m"), stack.Name)
+	return 0
 }

--- a/cmd/dockcd/serve.go
+++ b/cmd/dockcd/serve.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mohitsharma44/dockcd/internal/config"
 	"github.com/mohitsharma44/dockcd/internal/git"
 	"github.com/mohitsharma44/dockcd/internal/metrics"
+	"github.com/mohitsharma44/dockcd/internal/notify"
 	"github.com/mohitsharma44/dockcd/internal/reconciler"
 	"github.com/mohitsharma44/dockcd/internal/server"
 )
@@ -218,9 +219,9 @@ func runServe(args []string) int {
 		return 1
 	}
 
-	// Setup HTTP server for /metrics and /healthz.
+	// Create shared status and event bus.
 	status := &server.Status{}
-	srv := server.New(fmt.Sprintf(":%d", *metricsPort), status, logger, nil, nil, nil)
+	eventBus := notify.NewEventBus()
 
 	// Create git poller and reconciler.
 	poller := git.NewPoller(cfg.Repo, *repoDir)
@@ -239,11 +240,16 @@ func runServe(args []string) int {
 		Metrics:      m,
 		Status:       status,
 		Logger:       logger,
+		EventBus:     eventBus,
 	})
 	if err != nil {
 		logger.Error("failed to create reconciler", "error", err)
 		return 1
 	}
+
+	// Setup HTTP server for /metrics and /healthz.
+	server.Version = Version
+	srv := server.New(fmt.Sprintf(":%d", *metricsPort), status, logger, poller, rec, eventBus)
 
 	// Start HTTP server in a goroutine (non-blocking).
 	go func() {
@@ -289,6 +295,8 @@ func runServe(args []string) int {
 	if err := tracerProvider.Shutdown(shutdownCtx); err != nil {
 		logger.Error("tracer provider shutdown failed", "error", err)
 	}
+
+	eventBus.Close()
 
 	return exitCode
 }

--- a/cmd/dockcd/serve.go
+++ b/cmd/dockcd/serve.go
@@ -1,0 +1,294 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/mohitsharma44/dockcd/internal/config"
+	"github.com/mohitsharma44/dockcd/internal/git"
+	"github.com/mohitsharma44/dockcd/internal/metrics"
+	"github.com/mohitsharma44/dockcd/internal/reconciler"
+	"github.com/mohitsharma44/dockcd/internal/server"
+)
+
+// tracerShutdown is implemented by both sdktrace.TracerProvider and noopShutdown.
+type tracerShutdown interface {
+	Shutdown(ctx context.Context) error
+}
+
+// noopShutdown wraps a noop TracerProvider with a no-op Shutdown method.
+type noopShutdown struct{}
+
+func (noopShutdown) Shutdown(context.Context) error { return nil }
+
+// setupTracing creates an OTel TracerProvider. If DOCKCD_OTEL_ENDPOINT is set,
+// traces are exported via OTLP gRPC (e.g. to Alloy -> Tempo). If unset, a true
+// no-op provider is used (zero overhead).
+func setupTracing(ctx context.Context, logger *slog.Logger) (tracerShutdown, error) {
+	endpoint := os.Getenv("DOCKCD_OTEL_ENDPOINT")
+
+	// No endpoint configured — use a true no-op TracerProvider (zero overhead).
+	if endpoint == "" {
+		logger.Info("tracing disabled (DOCKCD_OTEL_ENDPOINT not set)")
+		otel.SetTracerProvider(noop.NewTracerProvider())
+		return noopShutdown{}, nil
+	}
+
+	// Create OTLP gRPC exporter pointing at the configured endpoint.
+	// WithInsecure() because internal networks (Alloy) typically don't use TLS.
+	exporter, err := otlptracegrpc.New(ctx,
+		otlptracegrpc.WithEndpoint(endpoint),
+		otlptracegrpc.WithInsecure(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating OTLP trace exporter: %w", err)
+	}
+
+	// Resource describes "who is sending these traces" — like adding
+	// service.name and service.version tags to every span.
+	res, err := resource.Merge(
+		resource.Default(),
+		resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceName("dockcd"),
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating trace resource: %w", err)
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithResource(res),
+	)
+	otel.SetTracerProvider(tp)
+
+	logger.Info("tracing enabled", "endpoint", endpoint)
+	return tp, nil
+}
+
+// execCommand runs a shell command in the given directory.
+// Used as the production deploy.CommandRunner.
+func execCommand(ctx context.Context, dir string, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s %v: %w\n%s", name, args, err, out)
+	}
+	return nil
+}
+
+// execCommandOutput runs a shell command and returns its output.
+// Used as the production deploy.OutputRunner for health checks.
+func execCommandOutput(ctx context.Context, dir string, name string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	return cmd.CombinedOutput()
+}
+
+// runServe starts the dockcd daemon. It returns 0 on success and 1 on error.
+func runServe(args []string) int {
+	fs := flag.NewFlagSet("serve", flag.ExitOnError)
+	configPath := fs.String("config", "gitops.yaml", "path to gitops config file")
+	host := fs.String("host", "", "host name (overrides DOCKCD_HOST env and hostname)")
+	logFormat := fs.String("log-format", "text", "log format: text or json")
+	metricsPort := fs.Int("metrics-port", 0, "port for metrics and health HTTP server (default 9092, or DOCKCD_METRICS_PORT)")
+	repoDir := fs.String("repo-dir", "", "local git clone path (default /opt/dockcd/repo, or DOCKCD_REPO_DIR)")
+	pollInterval := fs.Duration("poll-interval", 0, "git poll interval (default 30s, or DOCKCD_POLL_INTERVAL)")
+	initialSync := fs.Bool("initial-sync", false, "deploy all stacks on first run (or DOCKCD_INITIAL_SYNC=true)")
+	_ = fs.Parse(args)
+
+	// Resolve metrics port: flag > env var > default 9092.
+	if *metricsPort == 0 {
+		if envPort := os.Getenv("DOCKCD_METRICS_PORT"); envPort != "" {
+			p, err := strconv.Atoi(envPort)
+			if err != nil {
+				slog.Error("invalid DOCKCD_METRICS_PORT", "value", envPort, "error", err)
+				return 1
+			}
+			*metricsPort = p
+		} else {
+			*metricsPort = 9092
+		}
+	}
+
+	// Resolve repo dir: flag > env var > default.
+	if *repoDir == "" {
+		if envDir := os.Getenv("DOCKCD_REPO_DIR"); envDir != "" {
+			*repoDir = envDir
+		} else {
+			*repoDir = "/opt/dockcd/repo"
+		}
+	}
+
+	// Resolve poll interval: flag > env var > default 30s.
+	if *pollInterval == 0 {
+		if envInterval := os.Getenv("DOCKCD_POLL_INTERVAL"); envInterval != "" {
+			d, err := time.ParseDuration(envInterval)
+			if err != nil {
+				slog.Error("invalid DOCKCD_POLL_INTERVAL", "value", envInterval, "error", err)
+				return 1
+			}
+			*pollInterval = d
+		} else {
+			*pollInterval = 30 * time.Second
+		}
+	}
+
+	// Resolve initial sync: flag > env var.
+	if !*initialSync {
+		*initialSync = os.Getenv("DOCKCD_INITIAL_SYNC") == "true"
+	}
+
+	// Setup logger.
+	var handler slog.Handler
+	switch *logFormat {
+	case "json":
+		handler = slog.NewJSONHandler(os.Stdout, nil)
+	default:
+		handler = slog.NewTextHandler(os.Stdout, nil)
+	}
+	logger := slog.New(handler)
+
+	// Load config.
+	cfg, err := config.Load(*configPath)
+	if err != nil {
+		logger.Error("failed to load config", "error", err)
+		return 1
+	}
+
+	// Resolve hostname.
+	hostname := *host
+	if hostname == "" {
+		hostname = os.Getenv("DOCKCD_HOST")
+	}
+	if hostname == "" {
+		hostname, err = os.Hostname()
+		if err != nil {
+			logger.Error("failed to get hostname", "error", err)
+			return 1
+		}
+	}
+
+	// Verify host exists in config.
+	hostCfg, ok := cfg.Hosts[hostname]
+	if !ok {
+		logger.Error("host not found in config", "host", hostname)
+		return 1
+	}
+
+	// Setup metrics — creates OTel MeterProvider backed by Prometheus exporter.
+	meterProvider, err := metrics.Setup()
+	if err != nil {
+		logger.Error("failed to setup metrics", "error", err)
+		return 1
+	}
+
+	meter := meterProvider.Meter("dockcd")
+	m, err := metrics.New(meter)
+	if err != nil {
+		logger.Error("failed to create metrics", "error", err)
+		return 1
+	}
+
+	// Setup tracing — exports spans via OTLP gRPC if DOCKCD_OTEL_ENDPOINT is set.
+	// If unset, tracing is a no-op (zero overhead).
+	tracerProvider, err := setupTracing(context.Background(), logger)
+	if err != nil {
+		logger.Error("failed to setup tracing", "error", err)
+		return 1
+	}
+
+	// Setup HTTP server for /metrics and /healthz.
+	status := &server.Status{}
+	srv := server.New(fmt.Sprintf(":%d", *metricsPort), status, logger)
+
+	// Create git poller and reconciler.
+	poller := git.NewPoller(cfg.Repo, *repoDir)
+	poller.SetStateFile(filepath.Join(*repoDir, ".dockcd_state"))
+
+	rec, err := reconciler.New(reconciler.Config{
+		Poller:       poller,
+		HostStacks:   hostCfg.Stacks,
+		Hostname:     hostname,
+		BasePath:     cfg.BasePath,
+		RepoDir:      *repoDir,
+		PollInterval: *pollInterval,
+		InitialSync:  *initialSync,
+		Runner:       execCommand,
+		OutputRunner: execCommandOutput,
+		Metrics:      m,
+		Status:       status,
+		Logger:       logger,
+	})
+	if err != nil {
+		logger.Error("failed to create reconciler", "error", err)
+		return 1
+	}
+
+	// Start HTTP server in a goroutine (non-blocking).
+	go func() {
+		logger.Info("http server starting", "port", *metricsPort)
+		if err := srv.Start(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("http server failed", "error", err)
+		}
+	}()
+
+	// Setup signal handling.
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	logger.Info("dockcd starting",
+		"host", hostname,
+		"repo", cfg.Repo,
+		"stacks", len(hostCfg.Stacks),
+		"poll_interval", *pollInterval,
+		"initial_sync", *initialSync,
+	)
+
+	// Run the reconcile loop — blocks until context is cancelled.
+	exitCode := 0
+	if err := rec.Run(ctx); err != nil {
+		logger.Error("reconciler failed", "error", err)
+		// Non-zero exit so systemd/k8s can detect the failure.
+		exitCode = 1
+	}
+	logger.Info("shutting down")
+
+	// Graceful shutdown: stop HTTP server, then flush metrics.
+	// context.Background() here because the signal context is already cancelled.
+	shutdownCtx := context.Background()
+
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		logger.Error("http server shutdown failed", "error", err)
+	}
+
+	if err := meterProvider.Shutdown(shutdownCtx); err != nil {
+		logger.Error("meter provider shutdown failed", "error", err)
+	}
+
+	if err := tracerProvider.Shutdown(shutdownCtx); err != nil {
+		logger.Error("tracer provider shutdown failed", "error", err)
+	}
+
+	return exitCode
+}

--- a/cmd/dockcd/serve.go
+++ b/cmd/dockcd/serve.go
@@ -220,7 +220,7 @@ func runServe(args []string) int {
 
 	// Setup HTTP server for /metrics and /healthz.
 	status := &server.Status{}
-	srv := server.New(fmt.Sprintf(":%d", *metricsPort), status, logger)
+	srv := server.New(fmt.Sprintf(":%d", *metricsPort), status, logger, nil, nil, nil)
 
 	// Create git poller and reconciler.
 	poller := git.NewPoller(cfg.Repo, *repoDir)

--- a/cmd/dockcd/serve.go
+++ b/cmd/dockcd/serve.go
@@ -223,6 +223,26 @@ func runServe(args []string) int {
 	status := &server.Status{}
 	eventBus := notify.NewEventBus()
 
+	// Build notifiers from config.
+	var notifierFilters []notify.NotifierWithFilter
+	for _, nc := range cfg.Notifications {
+		var n notify.Notifier
+		switch nc.Type {
+		case "slack":
+			n = notify.NewSlackNotifier(nc.Name, nc.URL)
+		case "webhook":
+			n = notify.NewWebhookNotifier(nc.Name, nc.URL)
+		}
+		events := make(map[notify.EventType]bool, len(nc.Events))
+		for _, e := range nc.Events {
+			events[notify.EventType(e)] = true
+		}
+		notifierFilters = append(notifierFilters, notify.NotifierWithFilter{
+			Notifier: n,
+			Events:   events,
+		})
+	}
+
 	// Create git poller and reconciler.
 	poller := git.NewPoller(cfg.Repo, *repoDir)
 	poller.SetStateFile(filepath.Join(*repoDir, ".dockcd_state"))
@@ -262,6 +282,13 @@ func runServe(args []string) int {
 	// Setup signal handling.
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
+
+	// Start notification dispatcher if any notifiers configured.
+	if len(notifierFilters) > 0 {
+		dispatcher := notify.NewDispatcher(eventBus, logger, notifierFilters)
+		go dispatcher.Start(ctx)
+		logger.Info("notification dispatcher started", "notifiers", len(notifierFilters))
+	}
 
 	logger.Info("dockcd starting",
 		"host", hostname,

--- a/cmd/dockcd/serve.go
+++ b/cmd/dockcd/serve.go
@@ -248,19 +248,20 @@ func runServe(args []string) int {
 	poller.SetStateFile(filepath.Join(*repoDir, ".dockcd_state"))
 
 	rec, err := reconciler.New(reconciler.Config{
-		Poller:       poller,
-		HostStacks:   hostCfg.Stacks,
-		Hostname:     hostname,
-		BasePath:     cfg.BasePath,
-		RepoDir:      *repoDir,
-		PollInterval: *pollInterval,
-		InitialSync:  *initialSync,
-		Runner:       execCommand,
-		OutputRunner: execCommandOutput,
-		Metrics:      m,
-		Status:       status,
-		Logger:       logger,
-		EventBus:     eventBus,
+		Poller:        poller,
+		HostStacks:    hostCfg.Stacks,
+		Hostname:      hostname,
+		BasePath:      cfg.BasePath,
+		RepoDir:       *repoDir,
+		DefaultBranch: cfg.Branch,
+		PollInterval:  *pollInterval,
+		InitialSync:   *initialSync,
+		Runner:        execCommand,
+		OutputRunner:  execCommandOutput,
+		Metrics:       m,
+		Status:        status,
+		Logger:        logger,
+		EventBus:      eventBus,
 	})
 	if err != nil {
 		logger.Error("failed to create reconciler", "error", err)

--- a/cmd/dockcd/stats.go
+++ b/cmd/dockcd/stats.go
@@ -1,0 +1,8 @@
+package main
+
+import "fmt"
+
+func runStats(args []string) int {
+	fmt.Println("not implemented: stats")
+	return 1
+}

--- a/cmd/dockcd/stats.go
+++ b/cmd/dockcd/stats.go
@@ -1,8 +1,28 @@
 package main
 
-import "fmt"
+import (
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
 
 func runStats(args []string) int {
-	fmt.Println("not implemented: stats")
-	return 1
+	fs := flag.NewFlagSet("stats", flag.ExitOnError)
+	srv := fs.String("server", resolveServerURL(nil), "dockcd server URL")
+	fs.Parse(args) //nolint:errcheck // ExitOnError handles errors
+
+	resp, err := http.Get(*srv + "/metrics")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	defer resp.Body.Close()
+
+	if _, err := io.Copy(os.Stdout, resp.Body); err != nil {
+		fmt.Fprintf(os.Stderr, "error reading response: %v\n", err)
+		return 1
+	}
+	return 0
 }

--- a/cmd/dockcd/suspend.go
+++ b/cmd/dockcd/suspend.go
@@ -1,8 +1,29 @@
 package main
 
-import "fmt"
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/mohitsharma44/dockcd/internal/client"
+)
 
 func runSuspend(args []string) int {
-	fmt.Println("not implemented: suspend")
-	return 1
+	if len(args) < 2 || args[0] != "stack" {
+		fmt.Fprintln(os.Stderr, "Usage: dockcd suspend stack <name> [flags]")
+		return 2
+	}
+	name := args[1]
+	fs := flag.NewFlagSet("suspend", flag.ExitOnError)
+	srv := fs.String("server", resolveServerURL(nil), "dockcd server URL")
+	fs.Parse(args[2:]) //nolint:errcheck // ExitOnError handles errors
+
+	c := client.New(*srv)
+	stack, err := c.Suspend(name)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	fmt.Printf("%s stack %q suspended\n", colorize("⏸", "\033[33m"), stack.Name)
+	return 0
 }

--- a/cmd/dockcd/suspend.go
+++ b/cmd/dockcd/suspend.go
@@ -1,0 +1,8 @@
+package main
+
+import "fmt"
+
+func runSuspend(args []string) int {
+	fmt.Println("not implemented: suspend")
+	return 1
+}

--- a/cmd/dockcd/version.go
+++ b/cmd/dockcd/version.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func runVersion(args []string) int {
+	fmt.Printf("dockcd client: %s (go: %s)\n", Version, runtime.Version())
+	return 0
+}

--- a/docs/superpowers/plans/2026-04-04-phase2-plan1-hooks-cli-api.md
+++ b/docs/superpowers/plans/2026-04-04-phase2-plan1-hooks-cli-api.md
@@ -1,0 +1,3598 @@
+# Phase 2 Plan 1: Hooks, CLI & API Surface, Force-Deploy
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add pre/post deploy hooks (enabling SOPS decryption), refactor dockcd into a single-binary CLI+daemon with Flux-style UX, and implement async force-deploy via API.
+
+**Architecture:** The current `main.go` becomes a subcommand router. `dockcd serve` runs the daemon (existing behavior). New CLI subcommands (`get`, `reconcile`, `suspend`, `resume`, `logs`, `stats`, `version`) are thin HTTP clients against new `/api/v1/*` endpoints. Hooks are shell commands executed before/after `docker compose up` in the deploy lifecycle. Force-deploy triggers an async reconcile via POST, with SSE streaming for progress. Suspend/resume state is persisted in the existing JSON state file.
+
+**Tech Stack:** Go stdlib (flag, net/http, encoding/json, os/exec), SSE via chunked HTTP, existing OTel + Prometheus stack. No new dependencies.
+
+**Conventions (read before starting any task):**
+- Follow existing patterns: table-driven tests, `writeTemp` helpers, `mockPoller`/`mockRunner` fakes
+- All tests use `-race` flag (CI enforces this)
+- Integration tests use `//go:build integration` tag and live in `*_integration_test.go`
+- Error wrapping: `fmt.Errorf("context: %w", err)`
+- Structured logging via `slog`
+- Config validation in `validate()` function
+- `deploy.Stack` is the deploy-time type, `config.Stack` is the config-time type
+
+---
+
+## File Map
+
+### New files
+```
+internal/hooks/hooks.go              # Hook execution: Run(ctx, HookConfig, stackDir, env) error
+internal/hooks/hooks_test.go         # Unit tests for hook execution
+internal/notify/event.go             # Event types and EventBus
+internal/notify/event_test.go        # EventBus tests
+internal/client/client.go            # HTTP client for CLI commands
+internal/client/client_test.go       # Client tests with httptest
+cmd/dockcd/serve.go                  # Daemon startup (extracted from main.go)
+cmd/dockcd/get.go                    # CLI: get stacks / get stack <name>
+cmd/dockcd/reconcile.go              # CLI: reconcile stack(s)
+cmd/dockcd/suspend.go                # CLI: suspend/resume stack
+cmd/dockcd/logs.go                   # CLI: stream logs
+cmd/dockcd/stats.go                  # CLI: formatted metrics summary
+cmd/dockcd/version.go                # CLI: client + server version
+cmd/dockcd/output.go                 # Shared CLI output formatting (table, color, JSON)
+```
+
+### Modified files
+```
+internal/config/config.go            # Add Hook, Notification, Branch fields to Stack/Config
+internal/config/config_test.go       # Tests for new config fields and validation
+internal/deploy/graph.go             # Add Hooks field to deploy.Stack
+internal/deploy/compose.go           # Integrate hook execution into Deploy lifecycle
+internal/deploy/compose_test.go      # Tests for hooks in deploy
+internal/git/poller.go               # Add SuspendedStacks to State, add suspend/resume methods
+internal/git/poller_test.go          # Tests for suspend state persistence
+internal/reconciler/reconciler.go    # Suspend filtering, async reconcile, event emission, hook env vars
+internal/reconciler/reconciler_test.go # Tests for suspend, async reconcile
+internal/reconciler/reconciler_integration_test.go # Integration tests for hooks + suspend
+internal/server/server.go            # New API endpoints, SSE streaming, log ring buffer
+internal/server/server_test.go       # Tests for all new endpoints
+cmd/dockcd/main.go                   # Refactor to subcommand router
+examples/gitops.yaml                 # Update with hook and notification examples
+```
+
+---
+
+## Task 1: Hook Execution Package
+
+**Files:**
+- Create: `internal/hooks/hooks.go`
+- Create: `internal/hooks/hooks_test.go`
+
+### Verification Spec
+
+**Functional:**
+- `Run()` executes a shell command via `sh -c` in the specified working directory
+- `Run()` injects `DOCKCD_STACK_NAME`, `DOCKCD_COMMIT`, `DOCKCD_REPO_DIR`, `DOCKCD_BRANCH` into the command environment
+- `Run()` inherits the parent process environment (so `SOPS_AGE_KEY_FILE` etc. are available)
+- `Run()` returns nil on exit code 0
+- `Run()` returns a descriptive error on non-zero exit code, including stderr output
+- `Run()` respects context cancellation (command is killed)
+- `Run()` enforces the configured timeout (returns error after timeout)
+- `Run()` with zero/unset timeout uses a 30s default
+- Stdout and stderr are captured and returned alongside the error for logging
+
+**Non-functional:**
+- No goroutine leaks: cancelled/timed-out commands clean up child processes
+- No race conditions: safe to call Run() from multiple goroutines concurrently (stateless function)
+- Test coverage: every code path (success, failure, timeout, cancel, env vars)
+
+**Edge cases to test:**
+- Command that writes to stdout and stderr
+- Command that exits with code 1
+- Command that hangs (timeout triggers)
+- Context cancelled before command finishes
+- Empty command string (error)
+- Working directory that doesn't exist (error)
+
+---
+
+- [ ] **Step 1: Define the Hook types**
+
+```go
+// internal/hooks/hooks.go
+package hooks
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"time"
+)
+
+// DefaultTimeout is used when no timeout is configured for a hook.
+const DefaultTimeout = 30 * time.Second
+
+// Config describes a single hook to execute.
+type Config struct {
+	Command string
+	Timeout time.Duration
+}
+
+// Env holds the environment variables injected into hook commands.
+type Env struct {
+	StackName string
+	Commit    string
+	RepoDir   string
+	Branch    string
+}
+
+// Result holds the output from a hook execution.
+type Result struct {
+	Stdout string
+	Stderr string
+}
+```
+
+- [ ] **Step 2: Write failing tests for Run()**
+
+```go
+// internal/hooks/hooks_test.go
+package hooks
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunSuccess(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{Command: "echo hello", Timeout: 5 * time.Second}
+	env := Env{StackName: "web", Commit: "abc123", RepoDir: "/opt/repo", Branch: "main"}
+
+	result, err := Run(context.Background(), cfg, dir, env)
+	if err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+	if !strings.Contains(result.Stdout, "hello") {
+		t.Errorf("expected stdout to contain 'hello', got %q", result.Stdout)
+	}
+}
+
+func TestRunFailure(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{Command: "exit 1", Timeout: 5 * time.Second}
+	env := Env{StackName: "web", Commit: "abc123", RepoDir: "/opt/repo", Branch: "main"}
+
+	_, err := Run(context.Background(), cfg, dir, env)
+	if err == nil {
+		t.Fatal("expected error for non-zero exit")
+	}
+}
+
+func TestRunCapturesStderr(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{Command: "echo errout >&2; exit 1", Timeout: 5 * time.Second}
+	env := Env{StackName: "web", Commit: "abc123", RepoDir: "/opt/repo", Branch: "main"}
+
+	result, err := Run(context.Background(), cfg, dir, env)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(result.Stderr, "errout") {
+		t.Errorf("expected stderr to contain 'errout', got %q", result.Stderr)
+	}
+}
+
+func TestRunInjectsEnvVars(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{
+		Command: "echo $DOCKCD_STACK_NAME $DOCKCD_COMMIT $DOCKCD_REPO_DIR $DOCKCD_BRANCH",
+		Timeout: 5 * time.Second,
+	}
+	env := Env{StackName: "traefik", Commit: "def456", RepoDir: "/opt/repo", Branch: "canary"}
+
+	result, err := Run(context.Background(), cfg, dir, env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := "traefik def456 /opt/repo canary"
+	if strings.TrimSpace(result.Stdout) != expected {
+		t.Errorf("expected %q, got %q", expected, strings.TrimSpace(result.Stdout))
+	}
+}
+
+func TestRunTimeout(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{Command: "sleep 60", Timeout: 50 * time.Millisecond}
+	env := Env{}
+
+	_, err := Run(context.Background(), cfg, dir, env)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "signal") && !strings.Contains(err.Error(), "killed") && !strings.Contains(err.Error(), "context deadline exceeded") {
+		t.Errorf("expected timeout-related error, got: %v", err)
+	}
+}
+
+func TestRunContextCancel(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{Command: "sleep 60", Timeout: 10 * time.Second}
+	env := Env{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := Run(ctx, cfg, dir, env)
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+}
+
+func TestRunEmptyCommand(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{Command: "", Timeout: 5 * time.Second}
+	env := Env{}
+
+	_, err := Run(context.Background(), cfg, dir, env)
+	if err == nil {
+		t.Fatal("expected error for empty command")
+	}
+}
+
+func TestRunBadDirectory(t *testing.T) {
+	cfg := Config{Command: "echo hi", Timeout: 5 * time.Second}
+	env := Env{}
+
+	_, err := Run(context.Background(), cfg, "/nonexistent/dir/"+t.Name(), env)
+	if err == nil {
+		t.Fatal("expected error for nonexistent directory")
+	}
+}
+
+func TestRunDefaultTimeout(t *testing.T) {
+	dir := t.TempDir()
+	cfg := Config{Command: "echo ok", Timeout: 0} // zero means use default
+	env := Env{}
+
+	result, err := Run(context.Background(), cfg, dir, env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result.Stdout, "ok") {
+		t.Errorf("expected stdout 'ok', got %q", result.Stdout)
+	}
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7 && go test -race -v ./internal/hooks/`
+Expected: Compilation error — `Run` function doesn't exist yet
+
+- [ ] **Step 4: Implement Run()**
+
+```go
+// Add to internal/hooks/hooks.go after the type definitions:
+
+// Run executes a hook command via sh -c in the given directory.
+// It injects dockcd environment variables and enforces a timeout.
+func Run(ctx context.Context, cfg Config, dir string, env Env) (Result, error) {
+	if cfg.Command == "" {
+		return Result{}, fmt.Errorf("hook command is empty")
+	}
+
+	timeout := cfg.Timeout
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", cfg.Command)
+	cmd.Dir = dir
+
+	// Inherit parent environment and add dockcd-specific vars.
+	cmd.Env = append(cmd.Environ(),
+		"DOCKCD_STACK_NAME="+env.StackName,
+		"DOCKCD_COMMIT="+env.Commit,
+		"DOCKCD_REPO_DIR="+env.RepoDir,
+		"DOCKCD_BRANCH="+env.Branch,
+	)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+
+	result := Result{
+		Stdout: stdout.String(),
+		Stderr: stderr.String(),
+	}
+
+	if err != nil {
+		return result, fmt.Errorf("hook %q: %w\nstderr: %s", cfg.Command, err, stderr.String())
+	}
+	return result, nil
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7 && go test -race -v ./internal/hooks/`
+Expected: All 8 tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7
+git add internal/hooks/hooks.go internal/hooks/hooks_test.go
+git commit -m "feat: add hook execution package with timeout and env injection"
+```
+
+---
+
+## Task 2: Config — Add Hook, Branch, and Notification Fields
+
+**Files:**
+- Modify: `internal/config/config.go`
+- Modify: `internal/config/config_test.go`
+- Modify: `examples/gitops.yaml`
+
+### Verification Spec
+
+**Functional:**
+- `Config` gains a top-level `Branch` field (string, optional, defaults to "")
+- `Config` gains a top-level `Notifications` field (slice of `NotificationConfig`)
+- `Stack` gains a `Branch` field (string, optional)
+- `Stack` gains a `Hooks` field containing optional `PreDeploy` and `PostDeploy` hook configs
+- `HookConfig` has `Command` (string) and `Timeout` (duration, default 30s)
+- `NotificationConfig` has `Name`, `Type` (slack/webhook), `URL`, `Events` ([]string)
+- `os.ExpandEnv` is applied to the raw YAML bytes before unmarshaling (for `${VAR}` substitution)
+- Validation rejects: hook with empty command, notification with invalid type, notification with empty URL after expansion, notification with invalid event names
+- Validation accepts: stacks with no hooks (optional), stacks with only pre_deploy, stacks with only post_deploy
+- `Stack.Branch` defaults to `Config.Branch` at resolve time (not in config.go — that's the reconciler's job, config just stores the raw value)
+- Backward compatible: existing configs without hooks/notifications/branch still load correctly
+
+**Non-functional:**
+- No new dependencies added
+- Existing tests still pass unchanged
+- Table-driven test pattern maintained
+
+**Edge cases to test:**
+- Hook with timeout "0s" (valid — means use default)
+- Hook with only pre_deploy, no post_deploy
+- Hook with only post_deploy, no pre_deploy
+- Notification URL containing `${UNSET_VAR}` expands to empty string → validation error
+- Config with no notifications section (valid)
+- Config with empty notifications list (valid)
+- Invalid notification type (e.g., "discord") → validation error
+- Invalid event name → validation error
+- Env var substitution in non-URL fields works too (e.g., repo URL)
+
+---
+
+- [ ] **Step 1: Write failing tests for new config fields**
+
+Add to `internal/config/config_test.go`:
+
+```go
+func TestLoadHooksConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "valid hooks",
+			yaml: `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+        hooks:
+          pre_deploy:
+            command: "sops-decrypt.sh"
+            timeout: 10s
+          post_deploy:
+            command: "cleanup.sh"
+`,
+			wantErr: "",
+		},
+		{
+			name: "pre_deploy only",
+			yaml: `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+        hooks:
+          pre_deploy:
+            command: "decrypt.sh"
+`,
+			wantErr: "",
+		},
+		{
+			name: "post_deploy only",
+			yaml: `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+        hooks:
+          post_deploy:
+            command: "notify.sh"
+`,
+			wantErr: "",
+		},
+		{
+			name: "hook with empty command",
+			yaml: `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+        hooks:
+          pre_deploy:
+            command: ""
+`,
+			wantErr: "hook command is required",
+		},
+		{
+			name: "no hooks (backward compat)",
+			yaml: `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+`,
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeTemp(t, tt.yaml)
+			_, err := Load(path)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadHookTimeout(t *testing.T) {
+	yaml := `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+        hooks:
+          pre_deploy:
+            command: "decrypt.sh"
+            timeout: 10s
+`
+	path := writeTemp(t, yaml)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	stack := cfg.Hosts["server01"].Stacks[0]
+	if stack.Hooks == nil || stack.Hooks.PreDeploy == nil {
+		t.Fatal("expected hooks.pre_deploy to be set")
+	}
+	if stack.Hooks.PreDeploy.Timeout != 10*time.Second {
+		t.Errorf("expected timeout 10s, got %v", stack.Hooks.PreDeploy.Timeout)
+	}
+}
+
+func TestLoadBranchConfig(t *testing.T) {
+	yaml := `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+branch: main
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+        branch: canary
+      - name: web
+        path: web/
+`
+	path := writeTemp(t, yaml)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Branch != "main" {
+		t.Errorf("expected top-level branch 'main', got %q", cfg.Branch)
+	}
+	stacks := cfg.Hosts["server01"].Stacks
+	if stacks[0].Branch != "canary" {
+		t.Errorf("expected app branch 'canary', got %q", stacks[0].Branch)
+	}
+	if stacks[1].Branch != "" {
+		t.Errorf("expected web branch empty (inherit), got %q", stacks[1].Branch)
+	}
+}
+
+func TestLoadNotifications(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "valid slack notification",
+			yaml: `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+notifications:
+  - name: slack-alerts
+    type: slack
+    url: "https://hooks.slack.com/services/T/B/xxx"
+    events: [deploy_success, deploy_failure]
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+`,
+			wantErr: "",
+		},
+		{
+			name: "valid webhook notification",
+			yaml: `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+notifications:
+  - name: ntfy
+    type: webhook
+    url: "https://ntfy.sh/dockcd"
+    events: [deploy_failure]
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+`,
+			wantErr: "",
+		},
+		{
+			name: "invalid notification type",
+			yaml: `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+notifications:
+  - name: bad
+    type: discord
+    url: "https://example.com"
+    events: [deploy_failure]
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+`,
+			wantErr: "invalid notification type",
+		},
+		{
+			name: "empty URL",
+			yaml: `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+notifications:
+  - name: bad
+    type: slack
+    url: ""
+    events: [deploy_failure]
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+`,
+			wantErr: "notification URL is required",
+		},
+		{
+			name: "invalid event name",
+			yaml: `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+notifications:
+  - name: bad
+    type: slack
+    url: "https://hooks.slack.com/services/T/B/xxx"
+    events: [invalid_event]
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+`,
+			wantErr: "invalid event type",
+		},
+		{
+			name: "no notifications (backward compat)",
+			yaml: `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+`,
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeTemp(t, tt.yaml)
+			_, err := Load(path)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadEnvVarSubstitution(t *testing.T) {
+	t.Setenv("TEST_REPO_URL", "git@github.com:user/infra.git")
+	yaml := `
+repo: "${TEST_REPO_URL}"
+base_path: /opt/stacks
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+`
+	path := writeTemp(t, yaml)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Repo != "git@github.com:user/infra.git" {
+		t.Errorf("expected expanded repo URL, got %q", cfg.Repo)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7 && go test -race -v ./internal/config/ -run "TestLoadHooks|TestLoadBranch|TestLoadNotif|TestLoadEnvVar"`
+Expected: Compilation errors — new fields don't exist
+
+- [ ] **Step 3: Add new types to config.go**
+
+Add the following types and modify existing structs in `internal/config/config.go`:
+
+```go
+// Add to imports: "os"  (already present)
+
+// Valid notification types.
+var validNotificationTypes = map[string]bool{
+	"slack":   true,
+	"webhook": true,
+}
+
+// Valid event types for notifications.
+var validEventTypes = map[string]bool{
+	"deploy_success":     true,
+	"deploy_failure":     true,
+	"rollback_success":   true,
+	"rollback_failure":   true,
+	"reconcile_start":    true,
+	"reconcile_complete": true,
+	"force_deploy":       true,
+	"stack_suspended":    true,
+	"stack_resumed":      true,
+	"hook_failure":       true,
+}
+
+// HookConfig describes a single hook command.
+type HookConfig struct {
+	Command string        `yaml:"command"`
+	Timeout time.Duration `yaml:"timeout"`
+}
+
+// Hooks holds optional pre/post deploy hooks for a stack.
+type Hooks struct {
+	PreDeploy  *HookConfig `yaml:"pre_deploy"`
+	PostDeploy *HookConfig `yaml:"post_deploy"`
+}
+
+// NotificationConfig describes a notification target.
+type NotificationConfig struct {
+	Name   string   `yaml:"name"`
+	Type   string   `yaml:"type"`
+	URL    string   `yaml:"url"`
+	Events []string `yaml:"events"`
+}
+```
+
+Modify `Config` struct to add:
+```go
+type Config struct {
+	Repo          string                `yaml:"repo"`
+	BasePath      string                `yaml:"base_path"`
+	Branch        string                `yaml:"branch"`
+	Notifications []NotificationConfig  `yaml:"notifications"`
+	Hosts         map[string]HostConfig `yaml:"hosts"`
+}
+```
+
+Modify `Stack` struct to add `Branch` and `Hooks` fields, and update the `UnmarshalYAML` raw struct:
+```go
+type Stack struct {
+	Name               string         `yaml:"name"`
+	Path               string         `yaml:"path"`
+	Branch             string         `yaml:"branch"`
+	DependsOn          []string       `yaml:"depends_on"`
+	PostDeployDelay    time.Duration  `yaml:"post_deploy_delay"`
+	HealthCheckTimeout *time.Duration `yaml:"health_check_timeout"`
+	AutoRollback       *bool          `yaml:"auto_rollback"`
+	Hooks              *Hooks         `yaml:"hooks"`
+}
+```
+
+Update `UnmarshalYAML` to handle the new fields in the raw struct:
+```go
+func (s *Stack) UnmarshalYAML(value *yaml.Node) error {
+	var raw struct {
+		Name               string   `yaml:"name"`
+		Path               string   `yaml:"path"`
+		Branch             string   `yaml:"branch"`
+		DependsOn          []string `yaml:"depends_on"`
+		PostDeployDelay    string   `yaml:"post_deploy_delay"`
+		HealthCheckTimeout string   `yaml:"health_check_timeout"`
+		AutoRollback       *bool    `yaml:"auto_rollback"`
+		Hooks              *struct {
+			PreDeploy *struct {
+				Command string `yaml:"command"`
+				Timeout string `yaml:"timeout"`
+			} `yaml:"pre_deploy"`
+			PostDeploy *struct {
+				Command string `yaml:"command"`
+				Timeout string `yaml:"timeout"`
+			} `yaml:"post_deploy"`
+		} `yaml:"hooks"`
+	}
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+	s.Name = raw.Name
+	s.Path = raw.Path
+	s.Branch = raw.Branch
+	s.DependsOn = raw.DependsOn
+	s.AutoRollback = raw.AutoRollback
+
+	if raw.PostDeployDelay != "" {
+		d, err := time.ParseDuration(raw.PostDeployDelay)
+		if err != nil {
+			return fmt.Errorf("invalid post_deploy_delay %q for stack %q: %w", raw.PostDeployDelay, raw.Name, err)
+		}
+		s.PostDeployDelay = d
+	}
+	if raw.HealthCheckTimeout != "" {
+		d, err := time.ParseDuration(raw.HealthCheckTimeout)
+		if err != nil {
+			return fmt.Errorf("invalid health_check_timeout %q for stack %q: %w", raw.HealthCheckTimeout, raw.Name, err)
+		}
+		timeout := d
+		s.HealthCheckTimeout = &timeout
+	}
+
+	if raw.Hooks != nil {
+		s.Hooks = &Hooks{}
+		if raw.Hooks.PreDeploy != nil {
+			h := &HookConfig{Command: raw.Hooks.PreDeploy.Command}
+			if raw.Hooks.PreDeploy.Timeout != "" {
+				d, err := time.ParseDuration(raw.Hooks.PreDeploy.Timeout)
+				if err != nil {
+					return fmt.Errorf("invalid pre_deploy timeout %q for stack %q: %w", raw.Hooks.PreDeploy.Timeout, raw.Name, err)
+				}
+				h.Timeout = d
+			}
+			s.Hooks.PreDeploy = h
+		}
+		if raw.Hooks.PostDeploy != nil {
+			h := &HookConfig{Command: raw.Hooks.PostDeploy.Command}
+			if raw.Hooks.PostDeploy.Timeout != "" {
+				d, err := time.ParseDuration(raw.Hooks.PostDeploy.Timeout)
+				if err != nil {
+					return fmt.Errorf("invalid post_deploy timeout %q for stack %q: %w", raw.Hooks.PostDeploy.Timeout, raw.Name, err)
+				}
+				h.Timeout = d
+			}
+			s.Hooks.PostDeploy = h
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Add env var expansion and validation to Load()**
+
+Modify the `Load` function:
+```go
+func Load(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading config file: %w", err)
+	}
+
+	// Expand environment variables before parsing.
+	expanded := os.ExpandEnv(string(data))
+
+	var cfg Config
+	if err := yaml.Unmarshal([]byte(expanded), &cfg); err != nil {
+		return nil, fmt.Errorf("parsing config file: %w", err)
+	}
+
+	if err := validate(&cfg); err != nil {
+		return nil, fmt.Errorf("validating config: %w", err)
+	}
+
+	return &cfg, nil
+}
+```
+
+Add notification and hook validation to `validate()`:
+```go
+// Add at the end of the validate() function, before the final return:
+
+	// Validate notifications.
+	for i, n := range cfg.Notifications {
+		if !validNotificationTypes[n.Type] {
+			return fmt.Errorf("notification[%d] %q: invalid notification type %q (must be slack or webhook)", i, n.Name, n.Type)
+		}
+		if n.URL == "" {
+			return fmt.Errorf("notification[%d] %q: notification URL is required", i, n.Name)
+		}
+		for _, event := range n.Events {
+			if !validEventTypes[event] {
+				return fmt.Errorf("notification[%d] %q: invalid event type %q", i, n.Name, event)
+			}
+		}
+	}
+
+// Add inside the stack validation loop (after path check):
+
+			if st.Hooks != nil {
+				if st.Hooks.PreDeploy != nil && st.Hooks.PreDeploy.Command == "" {
+					return fmt.Errorf("host %q: stack %q: pre_deploy hook command is required", hostName, st.Name)
+				}
+				if st.Hooks.PostDeploy != nil && st.Hooks.PostDeploy.Command == "" {
+					return fmt.Errorf("host %q: stack %q: post_deploy hook command is required", hostName, st.Name)
+				}
+			}
+```
+
+- [ ] **Step 5: Run all config tests**
+
+Run: `cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7 && go test -race -v ./internal/config/`
+Expected: All tests PASS (both new and existing)
+
+- [ ] **Step 6: Update examples/gitops.yaml**
+
+```yaml
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+branch: main
+
+notifications:
+  - name: slack-alerts
+    type: slack
+    url: "${SLACK_WEBHOOK_URL}"
+    events:
+      - deploy_success
+      - deploy_failure
+      - rollback_success
+      - rollback_failure
+
+hosts:
+  server01:
+    stacks:
+      - name: monitoring
+        path: monitoring/
+        hooks:
+          pre_deploy:
+            command: "sops-decrypt.sh"
+            timeout: 15s
+      - name: app
+        path: app/
+        depends_on: [monitoring]
+        post_deploy_delay: 30s
+        health_check_timeout: 90s
+        auto_rollback: true
+        hooks:
+          pre_deploy:
+            command: "sops-decrypt.sh"
+```
+
+- [ ] **Step 7: Run full test suite to confirm no regressions**
+
+Run: `cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7 && go test -race ./...`
+Expected: All tests PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7
+git add internal/config/config.go internal/config/config_test.go examples/gitops.yaml
+git commit -m "feat: add hooks, branch, and notification config fields with env var substitution"
+```
+
+---
+
+## Task 3: Integrate Hooks into Deploy Lifecycle
+
+**Files:**
+- Modify: `internal/deploy/graph.go` (add hooks fields to `deploy.Stack`)
+- Modify: `internal/deploy/compose.go` (run hooks before/after compose)
+- Modify: `internal/deploy/compose_test.go` (test hook integration)
+- Modify: `internal/reconciler/reconciler.go` (pass hooks through to deploy, log hook output)
+- Modify: `internal/reconciler/reconciler_test.go` (test hooks in reconciler)
+
+### Verification Spec
+
+**Functional:**
+- `deploy.Stack` gains `PreDeployHook` and `PostDeployHook` fields (pointers to `hooks.Config`)
+- `deploy.Deploy()` accepts a `hooks.Env` parameter (or gets it via a new field)
+- Pre-deploy hook runs before `docker compose pull`, in the stack's directory
+- Post-deploy hook runs after `docker compose up -d`, in the stack's directory
+- If pre-deploy hook fails, deploy is skipped entirely and error is returned
+- If post-deploy hook fails, error is returned but deploy already happened (not rolled back)
+- If no hooks are configured, behavior is identical to current (backward compat)
+- Reconciler passes hook env vars (stack name, commit, repo dir, branch) through to deploy
+- Reconciler logs hook stdout at info level, stderr at warn level
+- During rollback, pre-deploy hook runs again (for the old commit's files)
+
+**Non-functional:**
+- Existing compose_test.go tests still pass unchanged
+- No additional goroutines or channels introduced
+- Hook failures are distinguishable from compose failures in error messages
+
+**Edge cases to test:**
+- Stack with pre_deploy hook only
+- Stack with post_deploy hook only
+- Stack with both hooks
+- Stack with no hooks (regression test — existing behavior)
+- Pre-deploy hook failure skips compose entirely (verify zero compose calls)
+- Post-deploy hook failure after successful compose (verify compose was called)
+
+---
+
+- [ ] **Step 1: Add hook fields to deploy.Stack**
+
+Modify `internal/deploy/graph.go`:
+
+```go
+// Add import for hooks package
+import (
+	"fmt"
+	"time"
+
+	"github.com/mohitsharma44/dockcd/internal/hooks"
+)
+
+// Add to Stack struct:
+type Stack struct {
+	Name               string
+	Path               string
+	DependsOn          []string
+	HealthCheckTimeout time.Duration
+	AutoRollback       bool
+	PreDeployHook      *hooks.Config
+	PostDeployHook     *hooks.Config
+}
+```
+
+- [ ] **Step 2: Write failing tests for hook integration in deploy**
+
+Add to `internal/deploy/compose_test.go`:
+
+```go
+func TestDeployRunsPreDeployHook(t *testing.T) {
+	dir := t.TempDir()
+	var calls []string
+	runner := func(ctx context.Context, d, name string, args ...string) error {
+		calls = append(calls, name+" "+strings.Join(args, " "))
+		return nil
+	}
+
+	stack := Stack{
+		Name: "web",
+		Path: ".",
+		PreDeployHook: &hooks.Config{Command: "echo pre", Timeout: 5 * time.Second},
+	}
+
+	env := hooks.Env{StackName: "web", Commit: "abc", RepoDir: dir, Branch: "main"}
+	err := Deploy(context.Background(), stack, dir, runner, env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should have: pre-hook ran (not tracked in calls since it uses sh -c),
+	// then compose pull + compose up.
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 compose calls, got %d: %v", len(calls), calls)
+	}
+}
+
+func TestDeployPreHookFailureSkipsCompose(t *testing.T) {
+	dir := t.TempDir()
+	var calls []string
+	runner := func(ctx context.Context, d, name string, args ...string) error {
+		calls = append(calls, name)
+		return nil
+	}
+
+	stack := Stack{
+		Name: "web",
+		Path: ".",
+		PreDeployHook: &hooks.Config{Command: "exit 1", Timeout: 5 * time.Second},
+	}
+
+	env := hooks.Env{StackName: "web", Commit: "abc", RepoDir: dir, Branch: "main"}
+	err := Deploy(context.Background(), stack, dir, runner, env)
+	if err == nil {
+		t.Fatal("expected error from failed pre-deploy hook")
+	}
+
+	// Compose should NOT have been called.
+	if len(calls) != 0 {
+		t.Errorf("expected 0 compose calls after pre-hook failure, got %d", len(calls))
+	}
+}
+
+func TestDeployPostHookFailureStillDeployed(t *testing.T) {
+	dir := t.TempDir()
+	var calls []string
+	runner := func(ctx context.Context, d, name string, args ...string) error {
+		calls = append(calls, name+" "+strings.Join(args, " "))
+		return nil
+	}
+
+	stack := Stack{
+		Name: "web",
+		Path: ".",
+		PostDeployHook: &hooks.Config{Command: "exit 1", Timeout: 5 * time.Second},
+	}
+
+	env := hooks.Env{StackName: "web", Commit: "abc", RepoDir: dir, Branch: "main"}
+	err := Deploy(context.Background(), stack, dir, runner, env)
+	if err == nil {
+		t.Fatal("expected error from failed post-deploy hook")
+	}
+
+	// Compose pull + up should have been called before the hook failed.
+	if len(calls) != 2 {
+		t.Errorf("expected 2 compose calls, got %d: %v", len(calls), calls)
+	}
+}
+
+func TestDeployNoHooksBackwardCompat(t *testing.T) {
+	dir := t.TempDir()
+	var calls []string
+	runner := func(ctx context.Context, d, name string, args ...string) error {
+		calls = append(calls, name)
+		return nil
+	}
+
+	stack := Stack{Name: "web", Path: "."}
+	env := hooks.Env{}
+	err := Deploy(context.Background(), stack, dir, runner, env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 calls (pull + up), got %d", len(calls))
+	}
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7 && go test -race -v ./internal/deploy/ -run "TestDeployRuns|TestDeployPre|TestDeployPost|TestDeployNoHooks"`
+Expected: Compilation errors — `Deploy` signature doesn't accept `hooks.Env`
+
+- [ ] **Step 4: Modify Deploy() to integrate hooks**
+
+Update `internal/deploy/compose.go`:
+
+```go
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/mohitsharma44/dockcd/internal/hooks"
+)
+
+// CommandRunner is a function that runs a shell command in a directory.
+type CommandRunner func(ctx context.Context, dir string, name string, args ...string) error
+
+// Deploy runs optional hooks and docker compose pull + up for a single stack.
+func Deploy(ctx context.Context, stack Stack, repoDir string, run CommandRunner, env hooks.Env) error {
+	if filepath.IsAbs(stack.Path) {
+		return fmt.Errorf("stack %q: path must be relative, got %q", stack.Name, stack.Path)
+	}
+
+	dir := filepath.Join(repoDir, stack.Path)
+
+	// Verify the resolved path is still within repoDir.
+	resolvedDir, err := filepath.Abs(dir)
+	if err != nil {
+		return fmt.Errorf("stack %q: resolving path: %w", stack.Name, err)
+	}
+	resolvedRepo, err := filepath.Abs(repoDir)
+	if err != nil {
+		return fmt.Errorf("stack %q: resolving repo dir: %w", stack.Name, err)
+	}
+	if !strings.HasPrefix(resolvedDir, resolvedRepo) {
+		return fmt.Errorf("stack %q: path %q escapes repo directory", stack.Name, stack.Path)
+	}
+
+	// Pre-deploy hook.
+	if stack.PreDeployHook != nil {
+		if _, err := hooks.Run(ctx, *stack.PreDeployHook, dir, env); err != nil {
+			return fmt.Errorf("stack %q: pre-deploy hook: %w", stack.Name, err)
+		}
+	}
+
+	if err := run(ctx, dir, "docker", "compose", "-p", stack.Name, "pull"); err != nil {
+		return fmt.Errorf("stack %q: compose pull: %w", stack.Name, err)
+	}
+
+	if err := run(ctx, dir, "docker", "compose", "-p", stack.Name, "up", "-d", "--remove-orphans"); err != nil {
+		return fmt.Errorf("stack %q: compose up: %w", stack.Name, err)
+	}
+
+	// Post-deploy hook.
+	if stack.PostDeployHook != nil {
+		if _, err := hooks.Run(ctx, *stack.PostDeployHook, dir, env); err != nil {
+			return fmt.Errorf("stack %q: post-deploy hook: %w", stack.Name, err)
+		}
+	}
+
+	return nil
+}
+```
+
+- [ ] **Step 5: Update all callers of Deploy() to pass hooks.Env**
+
+Update `internal/deploy/runner.go`:
+```go
+package deploy
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mohitsharma44/dockcd/internal/hooks"
+	"golang.org/x/sync/errgroup"
+)
+
+// RunGroups deploys stacks group by group. Groups run sequentially,
+// but stacks within a group run in parallel.
+func RunGroups(ctx context.Context, groups [][]Stack, repoDir string, run CommandRunner, env hooks.Env) error {
+	for i, group := range groups {
+		g, ctx := errgroup.WithContext(ctx)
+		for _, stack := range group {
+			stack := stack
+			g.Go(func() error {
+				return Deploy(ctx, stack, repoDir, run, env)
+			})
+		}
+		if err := g.Wait(); err != nil {
+			return fmt.Errorf("group %d: %w", i+1, err)
+		}
+	}
+	return nil
+}
+```
+
+Update `internal/reconciler/reconciler.go` — the `deployStack` method must build and pass `hooks.Env`, and `configToDeployStacks`/`filterChangedStacks` must map hook config:
+
+In `configToDeployStacks` and `filterChangedStacks`, add hook mapping:
+```go
+// In filterChangedStacks, when building deploy.Stack:
+var preHook, postHook *hooks.Config
+if cs.Hooks != nil {
+	if cs.Hooks.PreDeploy != nil {
+		preHook = &hooks.Config{Command: cs.Hooks.PreDeploy.Command, Timeout: cs.Hooks.PreDeploy.Timeout}
+	}
+	if cs.Hooks.PostDeploy != nil {
+		postHook = &hooks.Config{Command: cs.Hooks.PostDeploy.Command, Timeout: cs.Hooks.PostDeploy.Timeout}
+	}
+}
+stacks = append(stacks, deploy.Stack{
+	Name:               cs.Name,
+	Path:               filepath.Join(r.basePath, cs.Path),
+	DependsOn:          deps,
+	HealthCheckTimeout: cs.HealthTimeout(),
+	AutoRollback:       cs.RollbackEnabled(),
+	PreDeployHook:      preHook,
+	PostDeployHook:     postHook,
+})
+```
+
+Similarly update `configToDeployStacks`.
+
+In `deployStack`, construct and pass `hooks.Env`:
+```go
+func (r *Reconciler) deployStack(ctx context.Context, stack deploy.Stack, commitHash string) error {
+	env := hooks.Env{
+		StackName: stack.Name,
+		Commit:    commitHash,
+		RepoDir:   r.repoDir,
+		Branch:    "", // will be populated by multi-branch in Plan 2
+	}
+
+	if err := deploy.Deploy(ctx, stack, r.repoDir, r.runner, env); err != nil {
+		r.markStackHealth(ctx, stack.Name, false)
+		return err
+	}
+	// ... rest unchanged
+```
+
+Also update the rollback method to pass env:
+```go
+// In rollback(), the rollback deploy call:
+rollbackStack := deploy.Stack{Name: stack.Name, Path: "."}
+if err := deploy.Deploy(ctx, rollbackStack, tmpDir, r.runner, hooks.Env{
+	StackName: stack.Name,
+	Commit:    lastGood,
+	RepoDir:   r.repoDir,
+}); err != nil {
+```
+
+- [ ] **Step 6: Fix existing tests that call Deploy() without env parameter**
+
+Update all existing test calls to `Deploy()` and `RunGroups()` in:
+- `internal/deploy/compose_test.go` — add `hooks.Env{}` as the last parameter
+- `internal/deploy/runner_test.go` — add `hooks.Env{}` as the last parameter
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7 && go test -race ./...`
+Expected: All tests PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7
+git add internal/deploy/ internal/reconciler/ 
+git commit -m "feat: integrate pre/post deploy hooks into deploy lifecycle"
+```
+
+---
+
+## Task 4: Event Bus for Notifications and SSE
+
+**Files:**
+- Create: `internal/notify/event.go`
+- Create: `internal/notify/event_test.go`
+
+### Verification Spec
+
+**Functional:**
+- `EventType` is a string type with constants for all 10 event types
+- `Event` struct holds Type, Timestamp, Stack, Host, Commit, Branch, Message, Metadata
+- `EventBus` is a struct with `Emit(event)` and `Subscribe() <-chan Event` methods
+- `Emit` is non-blocking — if no subscribers, event is dropped
+- Multiple subscribers each get their own copy of every event
+- `Close()` closes all subscriber channels
+- Subscribers that fall behind get events dropped (buffered channel, not blocking sender)
+
+**Non-functional:**
+- Thread-safe: `Emit`, `Subscribe`, `Close` can be called concurrently
+- No goroutine leaks: `Close` cleans up everything
+- Buffer size: 64 events per subscriber (configurable if needed)
+
+**Edge cases to test:**
+- Emit with no subscribers (no panic, no block)
+- Multiple subscribers receive same event
+- Close then Emit (no panic)
+- Subscribe after Close (returns closed channel)
+- Slow subscriber doesn't block Emit or other subscribers
+
+---
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+// internal/notify/event_test.go
+package notify
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEventBusEmitToSubscriber(t *testing.T) {
+	bus := NewEventBus()
+	defer bus.Close()
+
+	ch := bus.Subscribe()
+	event := Event{Type: EventDeploySuccess, Stack: "web", Message: "ok"}
+	bus.Emit(event)
+
+	select {
+	case got := <-ch:
+		if got.Type != EventDeploySuccess {
+			t.Errorf("expected EventDeploySuccess, got %v", got.Type)
+		}
+		if got.Stack != "web" {
+			t.Errorf("expected stack 'web', got %q", got.Stack)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event")
+	}
+}
+
+func TestEventBusMultipleSubscribers(t *testing.T) {
+	bus := NewEventBus()
+	defer bus.Close()
+
+	ch1 := bus.Subscribe()
+	ch2 := bus.Subscribe()
+
+	event := Event{Type: EventDeployFailure, Stack: "db"}
+	bus.Emit(event)
+
+	for i, ch := range []<-chan Event{ch1, ch2} {
+		select {
+		case got := <-ch:
+			if got.Type != EventDeployFailure {
+				t.Errorf("subscriber %d: expected EventDeployFailure, got %v", i, got.Type)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("subscriber %d: timed out", i)
+		}
+	}
+}
+
+func TestEventBusEmitNoSubscribers(t *testing.T) {
+	bus := NewEventBus()
+	defer bus.Close()
+
+	// Should not panic or block.
+	bus.Emit(Event{Type: EventDeploySuccess})
+}
+
+func TestEventBusCloseClosesChannels(t *testing.T) {
+	bus := NewEventBus()
+	ch := bus.Subscribe()
+	bus.Close()
+
+	// Channel should be closed.
+	_, ok := <-ch
+	if ok {
+		t.Error("expected channel to be closed")
+	}
+}
+
+func TestEventBusEmitAfterClose(t *testing.T) {
+	bus := NewEventBus()
+	bus.Close()
+
+	// Should not panic.
+	bus.Emit(Event{Type: EventDeploySuccess})
+}
+
+func TestEventBusSlowSubscriberDoesNotBlock(t *testing.T) {
+	bus := NewEventBus()
+	defer bus.Close()
+
+	_ = bus.Subscribe() // slow subscriber — never reads
+	ch2 := bus.Subscribe()
+
+	// Fill beyond buffer.
+	for i := 0; i < 100; i++ {
+		bus.Emit(Event{Type: EventDeploySuccess, Message: "event"})
+	}
+
+	// Fast subscriber should still get events (may miss some due to slow sub dropping).
+	select {
+	case <-ch2:
+		// got at least one event — good
+	case <-time.After(time.Second):
+		t.Fatal("fast subscriber should receive events even with slow subscriber")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7 && go test -race -v ./internal/notify/`
+Expected: Compilation error — package doesn't exist
+
+- [ ] **Step 3: Implement event types and EventBus**
+
+```go
+// internal/notify/event.go
+package notify
+
+import (
+	"sync"
+	"time"
+)
+
+// EventType represents a dockcd lifecycle event.
+type EventType string
+
+const (
+	EventDeploySuccess     EventType = "deploy_success"
+	EventDeployFailure     EventType = "deploy_failure"
+	EventRollbackSuccess   EventType = "rollback_success"
+	EventRollbackFailure   EventType = "rollback_failure"
+	EventReconcileStart    EventType = "reconcile_start"
+	EventReconcileComplete EventType = "reconcile_complete"
+	EventForceDeploy       EventType = "force_deploy"
+	EventStackSuspended    EventType = "stack_suspended"
+	EventStackResumed      EventType = "stack_resumed"
+	EventHookFailure       EventType = "hook_failure"
+)
+
+// Event represents a single lifecycle event.
+type Event struct {
+	Type      EventType         `json:"type"`
+	Timestamp time.Time         `json:"timestamp"`
+	Stack     string            `json:"stack,omitempty"`
+	Host      string            `json:"host,omitempty"`
+	Commit    string            `json:"commit,omitempty"`
+	Branch    string            `json:"branch,omitempty"`
+	Message   string            `json:"message,omitempty"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+}
+
+const subscriberBuffer = 64
+
+// EventBus distributes events to all subscribers.
+type EventBus struct {
+	mu          sync.RWMutex
+	subscribers []chan Event
+	closed      bool
+}
+
+// NewEventBus creates a new EventBus.
+func NewEventBus() *EventBus {
+	return &EventBus{}
+}
+
+// Subscribe returns a channel that receives all future events.
+func (b *EventBus) Subscribe() <-chan Event {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	ch := make(chan Event, subscriberBuffer)
+	if b.closed {
+		close(ch)
+		return ch
+	}
+	b.subscribers = append(b.subscribers, ch)
+	return ch
+}
+
+// Emit sends an event to all subscribers. Non-blocking: if a subscriber's
+// buffer is full, the event is dropped for that subscriber.
+func (b *EventBus) Emit(event Event) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	if b.closed {
+		return
+	}
+
+	for _, ch := range b.subscribers {
+		select {
+		case ch <- event:
+		default:
+			// subscriber buffer full — drop event
+		}
+	}
+}
+
+// Close closes all subscriber channels. Safe to call multiple times.
+func (b *EventBus) Close() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.closed {
+		return
+	}
+	b.closed = true
+	for _, ch := range b.subscribers {
+		close(ch)
+	}
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7 && go test -race -v ./internal/notify/`
+Expected: All 6 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7
+git add internal/notify/event.go internal/notify/event_test.go
+git commit -m "feat: add event bus for lifecycle event distribution"
+```
+
+---
+
+## Task 5: Suspend/Resume State in Git Poller
+
+**Files:**
+- Modify: `internal/git/poller.go`
+- Modify: `internal/git/poller_test.go`
+- Modify: `internal/reconciler/reconciler.go`
+- Modify: `internal/reconciler/reconciler_test.go`
+
+### Verification Spec
+
+**Functional:**
+- `State` struct gains `SuspendedStacks []string` field
+- `Poller` gains `SuspendStack(name)` / `ResumeStack(name)` / `IsSuspended(name) bool` methods
+- `SuspendStack` adds to the set and persists to state file
+- `ResumeStack` removes from the set and persists; also marks stack as "needs reconcile"
+- `IsSuspended` returns true if stack is in suspended set
+- `SuspendStack` on already-suspended stack is a no-op (no error)
+- `ResumeStack` on non-suspended stack is a no-op (no error)
+- Suspended stacks survive restart (persisted in state file JSON)
+- `LoadState` reads suspended stacks from state file
+- Backward compat: state file without `suspended_stacks` field loads fine (empty set)
+- `Poller` gains `NeedsReconcile(name) bool` / `ClearNeedsReconcile(name)` for resume-triggered deploy
+- `GitPoller` interface in reconciler gains: `SuspendStack`, `ResumeStack`, `IsSuspended`, `NeedsReconcile`, `ClearNeedsReconcile`
+- Reconciler skips suspended stacks in `filterChangedStacks`
+- Reconciler checks `NeedsReconcile` during poll to deploy freshly resumed stacks
+
+**Non-functional:**
+- All state mutations protected by existing mutex
+- Existing state file migration (legacy format) still works
+
+**Edge cases to test:**
+- Suspend, restart (reload state), verify still suspended
+- Resume a stack that was never suspended (no-op)
+- Suspend stack, change detected, verify it's NOT deployed
+- Resume stack, verify next reconcile deploys it
+
+---
+
+- [ ] **Step 1: Write failing tests for poller suspend/resume**
+
+Add to `internal/git/poller_test.go`:
+
+```go
+func TestSuspendResumePersistence(t *testing.T) {
+	dir := t.TempDir()
+	stateFile := filepath.Join(dir, ".dockcd_state")
+
+	p := NewPoller("", dir)
+	p.SetStateFile(stateFile)
+	p.lastHash = "abc123"
+
+	// Suspend a stack.
+	if err := p.SuspendStack("web"); err != nil {
+		t.Fatalf("SuspendStack: %v", err)
+	}
+	if !p.IsSuspended("web") {
+		t.Error("expected web to be suspended")
+	}
+
+	// Reload state in a new poller.
+	p2 := NewPoller("", dir)
+	p2.SetStateFile(stateFile)
+	if err := p2.LoadState(); err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if !p2.IsSuspended("web") {
+		t.Error("expected web to be suspended after reload")
+	}
+
+	// Resume.
+	if err := p2.ResumeStack("web"); err != nil {
+		t.Fatalf("ResumeStack: %v", err)
+	}
+	if p2.IsSuspended("web") {
+		t.Error("expected web to NOT be suspended after resume")
+	}
+	if !p2.NeedsReconcile("web") {
+		t.Error("expected web to need reconcile after resume")
+	}
+}
+
+func TestSuspendIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	p := NewPoller("", dir)
+	p.SetStateFile(filepath.Join(dir, ".dockcd_state"))
+	p.lastHash = "abc"
+
+	if err := p.SuspendStack("web"); err != nil {
+		t.Fatal(err)
+	}
+	if err := p.SuspendStack("web"); err != nil {
+		t.Fatal(err)
+	}
+	if !p.IsSuspended("web") {
+		t.Error("expected suspended")
+	}
+}
+
+func TestResumeNotSuspended(t *testing.T) {
+	dir := t.TempDir()
+	p := NewPoller("", dir)
+	p.SetStateFile(filepath.Join(dir, ".dockcd_state"))
+	p.lastHash = "abc"
+
+	// Resume a stack that was never suspended — should be a no-op.
+	if err := p.ResumeStack("web"); err != nil {
+		t.Fatal(err)
+	}
+	if p.IsSuspended("web") {
+		t.Error("should not be suspended")
+	}
+}
+
+func TestBackwardCompatNoSuspendedField(t *testing.T) {
+	dir := t.TempDir()
+	stateFile := filepath.Join(dir, ".dockcd_state")
+
+	// Write state file without suspended_stacks field.
+	data := `{"last_hash":"abc","last_successful_commits":{"web":"abc"}}`
+	if err := os.WriteFile(stateFile, []byte(data), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := NewPoller("", dir)
+	p.SetStateFile(stateFile)
+	if err := p.LoadState(); err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if p.IsSuspended("web") {
+		t.Error("should not be suspended with legacy state file")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7 && go test -race -v ./internal/git/ -run "TestSuspend|TestResume|TestBackwardCompat"`
+Expected: Compilation errors
+
+- [ ] **Step 3: Implement suspend/resume in Poller**
+
+Add to `internal/git/poller.go`:
+
+Add `SuspendedStacks` to the `State` struct:
+```go
+type State struct {
+	LastHash              string            `json:"last_hash"`
+	LastSuccessfulCommits map[string]string `json:"last_successful_commits"`
+	SuspendedStacks       []string          `json:"suspended_stacks,omitempty"`
+}
+```
+
+Add `needsReconcile` field to `Poller`:
+```go
+type Poller struct {
+	repoURL        string
+	localDir       string
+	lastHash       string
+	stateFile      string
+	branch         string
+	state          State
+	needsReconcile map[string]bool
+	mu             sync.Mutex
+}
+```
+
+Initialize `needsReconcile` in `NewPoller`:
+```go
+func NewPoller(repoURL, localDir string) *Poller {
+	return &Poller{
+		repoURL:        repoURL,
+		localDir:       localDir,
+		state:          State{LastSuccessfulCommits: make(map[string]string)},
+		needsReconcile: make(map[string]bool),
+	}
+}
+```
+
+Add methods:
+```go
+// SuspendStack marks a stack as suspended and persists state.
+func (p *Poller) SuspendStack(name string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, s := range p.state.SuspendedStacks {
+		if s == name {
+			return nil // already suspended
+		}
+	}
+	p.state.SuspendedStacks = append(p.state.SuspendedStacks, name)
+	return p.saveStateLocked()
+}
+
+// ResumeStack removes a stack from the suspended set and marks it as needing reconcile.
+func (p *Poller) ResumeStack(name string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	filtered := p.state.SuspendedStacks[:0]
+	found := false
+	for _, s := range p.state.SuspendedStacks {
+		if s == name {
+			found = true
+			continue
+		}
+		filtered = append(filtered, s)
+	}
+	if !found {
+		return nil // wasn't suspended
+	}
+	p.state.SuspendedStacks = filtered
+	p.needsReconcile[name] = true
+	return p.saveStateLocked()
+}
+
+// IsSuspended returns true if the stack is currently suspended.
+func (p *Poller) IsSuspended(name string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, s := range p.state.SuspendedStacks {
+		if s == name {
+			return true
+		}
+	}
+	return false
+}
+
+// NeedsReconcile returns true if the stack was recently resumed and needs deployment.
+func (p *Poller) NeedsReconcile(name string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.needsReconcile[name]
+}
+
+// ClearNeedsReconcile clears the needs-reconcile flag for a stack.
+func (p *Poller) ClearNeedsReconcile(name string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.needsReconcile, name)
+}
+```
+
+- [ ] **Step 4: Update GitPoller interface and reconciler**
+
+Add new methods to the `GitPoller` interface in `internal/reconciler/reconciler.go`:
+```go
+type GitPoller interface {
+	Clone() error
+	Fetch() (bool, error)
+	ChangedStacks(sinceHash string, stackPaths map[string]string) ([]string, error)
+	LastHash() string
+	LoadState() error
+	LastSuccessfulCommit(stack string) string
+	SetLastSuccessfulCommit(stack, hash string) error
+	ExtractAtCommit(commit, pathPrefix, destDir string) error
+	SuspendStack(name string) error
+	ResumeStack(name string) error
+	IsSuspended(name string) bool
+	NeedsReconcile(name string) bool
+	ClearNeedsReconcile(name string)
+}
+```
+
+Update `filterChangedStacks` to skip suspended stacks:
+```go
+func (r *Reconciler) filterChangedStacks(changedNames []string) []deploy.Stack {
+	changedSet := make(map[string]bool, len(changedNames))
+	for _, name := range changedNames {
+		changedSet[name] = true
+	}
+
+	var stacks []deploy.Stack
+	for _, cs := range r.hostStacks {
+		if !changedSet[cs.Name] {
+			continue
+		}
+		// Skip suspended stacks.
+		if r.poller.IsSuspended(cs.Name) {
+			r.logger.Info("skipping suspended stack", "stack", cs.Name)
+			continue
+		}
+		// ... rest unchanged
+```
+
+Update `mockPoller` in `reconciler_test.go` to implement new interface methods (stub implementations returning defaults).
+
+- [ ] **Step 5: Write reconciler test for suspend behavior**
+
+Add to `internal/reconciler/reconciler_test.go`:
+
+```go
+func TestReconcileSkipsSuspendedStack(t *testing.T) {
+	stacks := []config.Stack{
+		{Name: "traefik", Path: "server04/traefik"},
+		{Name: "vault", Path: "server04/vault"},
+	}
+
+	poller := &mockPoller{
+		fetchChanged:    true,
+		lastHash:        "def456",
+		changedStacks:   []string{"traefik", "vault"},
+		suspendedStacks: map[string]bool{"vault": true},
+	}
+
+	var mu sync.Mutex
+	var calls []deployCall
+	r, _ := testReconciler(t, poller, stacks, mockRunner(&mu, &calls))
+
+	if err := r.reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Only traefik should be deployed (2 calls: pull + up).
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 deploy calls (traefik only), got %d", len(calls))
+	}
+	for _, c := range calls {
+		if c.dir != "/opt/repo/docker/stacks/server04/traefik" {
+			t.Errorf("unexpected deploy dir: %s", c.dir)
+		}
+	}
+}
+```
+
+Add `suspendedStacks` and `needsReconcileSet` fields to `mockPoller` and implement the interface methods.
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7 && go test -race ./...`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7
+git add internal/git/poller.go internal/git/poller_test.go internal/reconciler/reconciler.go internal/reconciler/reconciler_test.go
+git commit -m "feat: add suspend/resume with state persistence and reconciler filtering"
+```
+
+---
+
+## Task 6: Server API Endpoints
+
+**Files:**
+- Modify: `internal/server/server.go`
+- Modify: `internal/server/server_test.go`
+
+### Verification Spec
+
+**Functional:**
+- `GET /api/v1/stacks` returns JSON array of all stacks with status, health, branch, commit, suspended flag, last deploy time
+- `GET /api/v1/stacks/{name}` returns single stack detail; 404 if not found
+- `POST /api/v1/reconcile` triggers full reconcile, returns 202 with reconcile ID
+- `POST /api/v1/reconcile/{name}` triggers single-stack reconcile, returns 202; 404 if stack not found
+- `POST /api/v1/stacks/{name}/suspend` suspends a stack, returns updated stack object; 404 if not found
+- `POST /api/v1/stacks/{name}/resume` resumes a stack, returns updated stack object; 404 if not found
+- `GET /api/v1/reconcile/{id}/events` streams SSE events for a reconcile operation
+- `GET /api/v1/logs` streams SSE log events from ring buffer
+- `GET /api/v1/version` returns server version and go version
+- Existing `/healthz` and `/metrics` unchanged
+
+**Non-functional:**
+- All handlers tested with httptest (no real network)
+- SSE endpoints set correct headers (`Content-Type: text/event-stream`, `Cache-Control: no-cache`)
+- Reconcile endpoint is async — handler returns immediately, reconcile runs in background
+- Server needs access to: stack config, poller (for suspend/resume), reconciler (for triggering reconcile), event bus (for SSE)
+
+**Edge cases to test:**
+- GET /api/v1/stacks when no stacks configured (empty array, not null)
+- GET /api/v1/stacks/nonexistent (404 with JSON error body)
+- POST /api/v1/reconcile/nonexistent (404)
+- Suspend already-suspended stack (200, idempotent)
+- Resume non-suspended stack (200, idempotent)
+- SSE client disconnect (server-side cleanup, no goroutine leak)
+
+---
+
+- [ ] **Step 1: Define StackInfo and expanded Status types**
+
+The Server needs richer state. Add a `StackState` type and expand `Status` to track per-stack info:
+
+```go
+// Add to internal/server/server.go:
+
+// StackState tracks the runtime state of a single stack.
+type StackState struct {
+	Name       string    `json:"name"`
+	Host       string    `json:"host"`
+	Branch     string    `json:"branch"`
+	Status     string    `json:"status"`     // Ready, Failed, Suspended, Reconciling
+	Health     string    `json:"health"`     // Healthy, Degraded, Unknown
+	LastDeploy time.Time `json:"last_deploy"`
+	Commit     string    `json:"commit"`
+	Suspended  bool      `json:"suspended"`
+}
+```
+
+Add fields to `Status` for stack tracking and new dependencies:
+```go
+type Status struct {
+	mu         sync.RWMutex
+	lastSync   time.Time
+	commit     string
+	stacks     map[string]*StackState
+}
+
+// UpdateStack updates the state for a single stack.
+func (s *Status) UpdateStack(name string, state *StackState) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.stacks == nil {
+		s.stacks = make(map[string]*StackState)
+	}
+	s.stacks[name] = state
+}
+
+// GetStacks returns a snapshot of all stack states.
+func (s *Status) GetStacks() []StackState {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make([]StackState, 0, len(s.stacks))
+	for _, st := range s.stacks {
+		result = append(result, *st)
+	}
+	return result
+}
+
+// GetStack returns a single stack state, or nil if not found.
+func (s *Status) GetStack(name string) *StackState {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if st, ok := s.stacks[name]; ok {
+		cp := *st
+		return &cp
+	}
+	return nil
+}
+```
+
+- [ ] **Step 2: Write failing tests for new endpoints**
+
+Add to `internal/server/server_test.go`:
+
+```go
+func TestGetStacksEmpty(t *testing.T) {
+	status := &Status{}
+	srv := New(":0", status, nil, nil, nil, nil)
+
+	req := httptest.NewRequest("GET", "/api/v1/stacks", nil)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp struct {
+		Stacks []StackState `json:"stacks"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Stacks == nil {
+		t.Error("expected empty array, not null")
+	}
+}
+
+func TestGetStacksWithData(t *testing.T) {
+	status := &Status{}
+	status.UpdateStack("web", &StackState{
+		Name: "web", Host: "server01", Status: "Ready", Health: "Healthy",
+		Commit: "abc123", Branch: "main",
+	})
+
+	srv := New(":0", status, nil, nil, nil, nil)
+
+	req := httptest.NewRequest("GET", "/api/v1/stacks", nil)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp struct {
+		Stacks []StackState `json:"stacks"`
+	}
+	json.NewDecoder(rec.Body).Decode(&resp)
+	if len(resp.Stacks) != 1 {
+		t.Fatalf("expected 1 stack, got %d", len(resp.Stacks))
+	}
+	if resp.Stacks[0].Name != "web" {
+		t.Errorf("expected name 'web', got %q", resp.Stacks[0].Name)
+	}
+}
+
+func TestGetStackNotFound(t *testing.T) {
+	status := &Status{}
+	srv := New(":0", status, nil, nil, nil, nil)
+
+	req := httptest.NewRequest("GET", "/api/v1/stacks/nonexistent", nil)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestGetStackFound(t *testing.T) {
+	status := &Status{}
+	status.UpdateStack("web", &StackState{Name: "web", Status: "Ready"})
+	srv := New(":0", status, nil, nil, nil, nil)
+
+	req := httptest.NewRequest("GET", "/api/v1/stacks/web", nil)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}
+
+func TestVersionEndpoint(t *testing.T) {
+	srv := New(":0", &Status{}, nil, nil, nil, nil)
+
+	req := httptest.NewRequest("GET", "/api/v1/version", nil)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var resp map[string]string
+	json.NewDecoder(rec.Body).Decode(&resp)
+	if _, ok := resp["server"]; !ok {
+		t.Error("expected 'server' in version response")
+	}
+	if _, ok := resp["go"]; !ok {
+		t.Error("expected 'go' in version response")
+	}
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7 && go test -race -v ./internal/server/ -run "TestGetStacks|TestGetStack|TestVersion"`
+Expected: Compilation errors — `New()` signature changed, new types don't exist
+
+- [ ] **Step 4: Implement new API endpoints**
+
+This is a significant expansion of `server.go`. The `New()` function signature grows to accept dependencies needed by API handlers:
+
+```go
+// Reconciler interface for triggering reconciles from the API.
+type ReconcileTriggerer interface {
+	TriggerReconcile(ctx context.Context, stackName string) (string, error) // returns reconcile ID
+	TriggerReconcileAll(ctx context.Context) (string, error)
+}
+
+// Suspender interface for suspend/resume from the API.
+type Suspender interface {
+	SuspendStack(name string) error
+	ResumeStack(name string) error
+	IsSuspended(name string) bool
+}
+
+func New(addr string, status *Status, logger *slog.Logger, suspender Suspender, triggerer ReconcileTriggerer, eventBus *notify.EventBus) *Server {
+```
+
+Register all new routes:
+```go
+mux.Handle("GET /metrics", promhttp.Handler())
+mux.HandleFunc("GET /healthz", s.handleHealthz)
+mux.HandleFunc("GET /api/v1/stacks", s.handleGetStacks)
+mux.HandleFunc("GET /api/v1/stacks/{name}", s.handleGetStack)
+mux.HandleFunc("POST /api/v1/stacks/{name}/suspend", s.handleSuspend)
+mux.HandleFunc("POST /api/v1/stacks/{name}/resume", s.handleResume)
+mux.HandleFunc("POST /api/v1/reconcile", s.handleReconcileAll)
+mux.HandleFunc("POST /api/v1/reconcile/{name}", s.handleReconcile)
+mux.HandleFunc("GET /api/v1/reconcile/{id}/events", s.handleReconcileEvents)
+mux.HandleFunc("GET /api/v1/logs", s.handleLogs)
+mux.HandleFunc("GET /api/v1/version", s.handleVersion)
+```
+
+Implement each handler. The full implementations are straightforward JSON encode/decode handlers. The SSE endpoints (`/logs`, `/reconcile/{id}/events`) use `flusher, ok := w.(http.Flusher)` to stream.
+
+- [ ] **Step 5: Update existing New() call sites**
+
+Update `cmd/dockcd/main.go` where `server.New()` is called to pass the new parameters (nil for now — will be wired in the CLI refactor task).
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7 && go test -race ./...`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7
+git add internal/server/ cmd/dockcd/main.go
+git commit -m "feat: add API v1 endpoints for stacks, reconcile, suspend, resume, version"
+```
+
+---
+
+## Task 7: Reconciler — Async Reconcile Triggering and Event Emission
+
+**Files:**
+- Modify: `internal/reconciler/reconciler.go`
+- Modify: `internal/reconciler/reconciler_test.go`
+
+### Verification Spec
+
+**Functional:**
+- Reconciler gains `TriggerReconcile(ctx, stackName) (string, error)` method — triggers async single-stack deploy
+- Reconciler gains `TriggerReconcileAll(ctx) (string, error)` method — triggers async full deploy
+- Both return a reconcile ID (e.g., `"rec-<unix-timestamp>"`)
+- Reconcile runs in a background goroutine
+- Reconciler emits events on the EventBus at each lifecycle point: reconcile start, hook start/complete, deploy start, health check, rollback, reconcile complete
+- Reconciler accepts an `*notify.EventBus` in its Config
+- `TriggerReconcile` for a suspended stack returns an error
+- `TriggerReconcile` for a non-existent stack returns an error
+- Duplicate concurrent reconciles for the same stack are rejected (already reconciling)
+
+**Non-functional:**
+- Async reconcile goroutines clean up on context cancellation
+- No data races between poll-triggered reconcile and API-triggered reconcile (mutex or channel serialization)
+
+---
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `internal/reconciler/reconciler_test.go`:
+
+```go
+func TestTriggerReconcileNonExistentStack(t *testing.T) {
+	poller := &mockPoller{lastHash: "abc123"}
+	r, _ := testReconciler(t, poller, []config.Stack{{Name: "web", Path: "web"}}, nil)
+
+	_, err := r.TriggerReconcile(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent stack")
+	}
+}
+
+func TestTriggerReconcileSuspendedStack(t *testing.T) {
+	poller := &mockPoller{
+		lastHash:        "abc123",
+		suspendedStacks: map[string]bool{"web": true},
+	}
+	r, _ := testReconciler(t, poller, []config.Stack{{Name: "web", Path: "web"}}, nil)
+
+	_, err := r.TriggerReconcile(context.Background(), "web")
+	if err == nil {
+		t.Fatal("expected error for suspended stack")
+	}
+}
+
+func TestTriggerReconcileReturnsID(t *testing.T) {
+	poller := &mockPoller{lastHash: "abc123"}
+	r, _ := testReconciler(t, poller, []config.Stack{{Name: "web", Path: "web"}}, nil)
+
+	id, err := r.TriggerReconcile(context.Background(), "web")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id == "" {
+		t.Error("expected non-empty reconcile ID")
+	}
+	if !strings.HasPrefix(id, "rec-") {
+		t.Errorf("expected ID prefix 'rec-', got %q", id)
+	}
+}
+```
+
+- [ ] **Step 2: Implement TriggerReconcile and TriggerReconcileAll**
+
+Add to `internal/reconciler/reconciler.go`:
+
+```go
+import (
+	// add:
+	"strconv"
+	"github.com/mohitsharma44/dockcd/internal/notify"
+)
+
+// Add EventBus to Config and Reconciler:
+// Config.EventBus *notify.EventBus
+// Reconciler.eventBus *notify.EventBus
+
+func (r *Reconciler) TriggerReconcile(ctx context.Context, stackName string) (string, error) {
+	// Verify stack exists.
+	var found bool
+	for _, s := range r.hostStacks {
+		if s.Name == stackName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return "", fmt.Errorf("stack %q not found", stackName)
+	}
+
+	if r.poller.IsSuspended(stackName) {
+		return "", fmt.Errorf("stack %q is suspended", stackName)
+	}
+
+	id := "rec-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+
+	go func() {
+		r.logger.Info("force reconcile triggered", "stack", stackName, "id", id)
+		// Fetch latest
+		if _, err := r.poller.Fetch(); err != nil {
+			r.logger.Error("force reconcile fetch failed", "stack", stackName, "error", err)
+			return
+		}
+		// Build and deploy single stack
+		stacks := r.filterStackByName(stackName)
+		if len(stacks) == 0 {
+			return
+		}
+		groups, err := deploy.BuildGraph(stacks)
+		if err != nil {
+			r.logger.Error("force reconcile graph failed", "stack", stackName, "error", err)
+			return
+		}
+		commitHash := r.poller.LastHash()
+		if err := r.deployGroups(ctx, groups, commitHash); err != nil && !errors.Is(err, ErrRolledBack) {
+			r.logger.Error("force reconcile deploy failed", "stack", stackName, "error", err)
+		}
+		r.status.Update(time.Now(), commitHash)
+	}()
+
+	return id, nil
+}
+
+func (r *Reconciler) TriggerReconcileAll(ctx context.Context) (string, error) {
+	id := "rec-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+
+	go func() {
+		r.logger.Info("force reconcile all triggered", "id", id)
+		if _, err := r.poller.Fetch(); err != nil {
+			r.logger.Error("force reconcile fetch failed", "error", err)
+			return
+		}
+		if err := r.deployAll(ctx); err != nil {
+			r.logger.Error("force reconcile deploy failed", "error", err)
+		}
+		r.status.Update(time.Now(), r.poller.LastHash())
+	}()
+
+	return id, nil
+}
+
+// filterStackByName returns a single stack as a deploy.Stack slice (for force-deploy).
+func (r *Reconciler) filterStackByName(name string) []deploy.Stack {
+	for _, cs := range r.hostStacks {
+		if cs.Name == name {
+			return r.configToDeployStacks([]config.Stack{cs})
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 3: Add event emission at lifecycle points**
+
+Add helper method:
+```go
+func (r *Reconciler) emit(eventType notify.EventType, stack, commit, msg string) {
+	if r.eventBus == nil {
+		return
+	}
+	r.eventBus.Emit(notify.Event{
+		Type:      eventType,
+		Timestamp: time.Now(),
+		Stack:     stack,
+		Host:      r.hostname,
+		Commit:    commit,
+		Message:   msg,
+	})
+}
+```
+
+Add `r.emit(...)` calls at key points in `reconcile()`, `deployStack()`, `rollback()`.
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7 && go test -race ./...`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7
+git add internal/reconciler/
+git commit -m "feat: add async reconcile triggering and event emission"
+```
+
+---
+
+## Task 8: CLI Subcommand Router and Serve Command
+
+**Files:**
+- Modify: `cmd/dockcd/main.go` (refactor to subcommand router)
+- Create: `cmd/dockcd/serve.go` (extract daemon startup)
+
+### Verification Spec
+
+**Functional:**
+- `dockcd` with no args starts the daemon (backward compat)
+- `dockcd serve` starts the daemon
+- `dockcd serve --config`, `--host`, `--log-format`, `--metrics-port`, `--repo-dir`, `--poll-interval`, `--initial-sync` all work as before
+- Unknown subcommand prints usage and exits 2
+- `dockcd version` prints version (even without a server running)
+- All existing flags on the daemon still work identically
+
+**Non-functional:**
+- Existing systemd units and Dockerfiles work unchanged (no args = serve)
+- No new dependencies (stdlib flag only)
+- Clean separation: main.go is <30 lines, serve.go contains daemon logic
+
+**Edge cases:**
+- `dockcd --help` prints usage for all subcommands
+- `dockcd serve --help` prints serve-specific flags
+- `dockcd unknowncommand` exits 2 with error message
+
+---
+
+- [ ] **Step 1: Create serve.go with extracted daemon logic**
+
+Move the body of `main()` from `main.go` into a `runServe(args []string) int` function in `cmd/dockcd/serve.go`. The function accepts os.Args[2:] (or os.Args[1:] if no subcommand), parses flags, and returns an exit code.
+
+```go
+// cmd/dockcd/serve.go
+package main
+
+import (
+	// all current imports from main.go
+)
+
+func runServe(args []string) int {
+	fs := flag.NewFlagSet("serve", flag.ExitOnError)
+	configPath := fs.String("config", "gitops.yaml", "path to gitops config file")
+	// ... all current flags ...
+	fs.Parse(args)
+
+	// ... entire current main() body, but return 0/1 instead of os.Exit ...
+}
+```
+
+- [ ] **Step 2: Refactor main.go to subcommand router**
+
+```go
+// cmd/dockcd/main.go
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// Version is set at build time via -ldflags.
+var Version = "dev"
+
+func main() {
+	if len(os.Args) < 2 {
+		// No subcommand — default to serve (backward compat).
+		os.Exit(runServe(os.Args[1:]))
+	}
+
+	switch os.Args[1] {
+	case "serve":
+		os.Exit(runServe(os.Args[2:]))
+	case "version":
+		os.Exit(runVersion(os.Args[2:]))
+	case "get":
+		os.Exit(runGet(os.Args[2:]))
+	case "reconcile":
+		os.Exit(runReconcile(os.Args[2:]))
+	case "suspend":
+		os.Exit(runSuspend(os.Args[2:]))
+	case "resume":
+		os.Exit(runResume(os.Args[2:]))
+	case "logs":
+		os.Exit(runLogs(os.Args[2:]))
+	case "stats":
+		os.Exit(runStats(os.Args[2:]))
+	default:
+		// Check if it looks like a flag (e.g. --config) — treat as serve.
+		if len(os.Args[1]) > 0 && os.Args[1][0] == '-' {
+			os.Exit(runServe(os.Args[1:]))
+		}
+		fmt.Fprintf(os.Stderr, "unknown command: %s\n", os.Args[1])
+		printUsage()
+		os.Exit(2)
+	}
+}
+
+func printUsage() {
+	fmt.Fprintln(os.Stderr, `Usage: dockcd <command> [flags]
+
+Commands:
+  serve       Start the dockcd daemon (default if no command given)
+  get         Get stack status (get stacks | get stack <name>)
+  reconcile   Trigger reconciliation (reconcile stacks | reconcile stack <name>)
+  suspend     Suspend a stack (suspend stack <name>)
+  resume      Resume a stack (resume stack <name>)
+  logs        Stream server logs
+  stats       Show metrics summary
+  version     Show client and server version`)
+}
+```
+
+- [ ] **Step 3: Create stub functions for unimplemented commands**
+
+Create minimal stubs for `runGet`, `runReconcile`, `runSuspend`, `runResume`, `runLogs`, `runStats` that print "not implemented" and return 1. These will be implemented in subsequent tasks.
+
+```go
+// cmd/dockcd/get.go
+package main
+
+import "fmt"
+
+func runGet(args []string) int {
+	fmt.Println("not implemented")
+	return 1
+}
+```
+
+(Similar for each command file.)
+
+- [ ] **Step 4: Create version command**
+
+```go
+// cmd/dockcd/version.go
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"runtime"
+)
+
+func runVersion(args []string) int {
+	fmt.Printf("dockcd client: %s (go: %s)\n", Version, runtime.Version())
+
+	// Try to reach server for server version.
+	serverURL := resolveServerURL(args)
+	resp, err := http.Get(serverURL + "/api/v1/version")
+	if err != nil {
+		fmt.Println("server: unreachable")
+		return 0
+	}
+	defer resp.Body.Close()
+
+	var ver map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&ver); err != nil {
+		fmt.Println("server: error reading version")
+		return 0
+	}
+	fmt.Printf("dockcd server: %s (go: %s)\n", ver["server"], ver["go"])
+	return 0
+}
+```
+
+- [ ] **Step 5: Verify build and backward compat**
+
+Run: `cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7 && go build ./cmd/dockcd/`
+Expected: Builds successfully
+
+Run: `cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7 && go test -race ./...`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7
+git add cmd/dockcd/
+git commit -m "feat: refactor to subcommand router with serve extraction and version command"
+```
+
+---
+
+## Task 9: HTTP Client Package and CLI Output Formatting
+
+**Files:**
+- Create: `internal/client/client.go`
+- Create: `internal/client/client_test.go`
+- Create: `cmd/dockcd/output.go`
+
+### Verification Spec
+
+**Functional:**
+- `client.Client` wraps HTTP calls to the dockcd server API
+- `Client.GetStacks() ([]StackState, error)`
+- `Client.GetStack(name) (*StackState, error)` — returns typed error for 404
+- `Client.Reconcile(name) (ReconcileResponse, error)` — single stack
+- `Client.ReconcileAll() (ReconcileResponse, error)` — all stacks
+- `Client.Suspend(name) (*StackState, error)`
+- `Client.Resume(name) (*StackState, error)`
+- `Client.StreamEvents(reconcileID) (<-chan Event, error)` — SSE stream
+- `Client.Version() (VersionResponse, error)`
+- All methods handle non-2xx responses with descriptive errors
+- `output.go` provides `PrintStacksTable(stacks, noColor)` and `PrintJSON(v)`
+
+**Non-functional:**
+- Client tested against httptest servers (no real network)
+- Client respects context for cancellation
+- Table output aligns columns properly
+- Color output disabled when `NO_COLOR` is set or `--no-color` flag
+
+---
+
+- [ ] **Step 1: Write failing tests for client**
+
+```go
+// internal/client/client_test.go
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mohitsharma44/dockcd/internal/server"
+)
+
+func TestGetStacks(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/stacks" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"stacks": []server.StackState{
+				{Name: "web", Status: "Ready", Health: "Healthy"},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL)
+	stacks, err := c.GetStacks()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(stacks) != 1 {
+		t.Fatalf("expected 1 stack, got %d", len(stacks))
+	}
+	if stacks[0].Name != "web" {
+		t.Errorf("expected name 'web', got %q", stacks[0].Name)
+	}
+}
+
+func TestGetStackNotFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL)
+	_, err := c.GetStack("missing")
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+}
+
+func TestReconcile(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusAccepted)
+		json.NewEncoder(w).Encode(map[string]string{"id": "rec-123", "status": "queued"})
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL)
+	resp, err := c.Reconcile("web")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.ID != "rec-123" {
+		t.Errorf("expected ID 'rec-123', got %q", resp.ID)
+	}
+}
+```
+
+- [ ] **Step 2: Implement client package**
+
+```go
+// internal/client/client.go
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/mohitsharma44/dockcd/internal/server"
+)
+
+// Client is an HTTP client for the dockcd API.
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// ReconcileResponse is returned by the reconcile endpoint.
+type ReconcileResponse struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+	Stack  string `json:"stack,omitempty"`
+}
+
+// VersionResponse is returned by the version endpoint.
+type VersionResponse struct {
+	Server string `json:"server"`
+	Go     string `json:"go"`
+}
+
+// New creates a Client for the given server URL.
+func New(baseURL string) *Client {
+	return &Client{baseURL: baseURL, httpClient: &http.Client{}}
+}
+
+func (c *Client) GetStacks() ([]server.StackState, error) {
+	resp, err := c.httpClient.Get(c.baseURL + "/api/v1/stacks")
+	if err != nil {
+		return nil, fmt.Errorf("connecting to server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("server returned %d", resp.StatusCode)
+	}
+
+	var result struct {
+		Stacks []server.StackState `json:"stacks"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	return result.Stacks, nil
+}
+
+func (c *Client) GetStack(name string) (*server.StackState, error) {
+	resp, err := c.httpClient.Get(c.baseURL + "/api/v1/stacks/" + name)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("stack %q not found", name)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("server returned %d", resp.StatusCode)
+	}
+
+	var state server.StackState
+	if err := json.NewDecoder(resp.Body).Decode(&state); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	return &state, nil
+}
+
+func (c *Client) Reconcile(name string) (ReconcileResponse, error) {
+	resp, err := c.httpClient.Post(c.baseURL+"/api/v1/reconcile/"+name, "application/json", nil)
+	if err != nil {
+		return ReconcileResponse{}, fmt.Errorf("connecting to server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return ReconcileResponse{}, fmt.Errorf("stack %q not found", name)
+	}
+	if resp.StatusCode != http.StatusAccepted {
+		return ReconcileResponse{}, fmt.Errorf("server returned %d", resp.StatusCode)
+	}
+
+	var result ReconcileResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return ReconcileResponse{}, fmt.Errorf("decoding response: %w", err)
+	}
+	return result, nil
+}
+
+func (c *Client) ReconcileAll() (ReconcileResponse, error) {
+	resp, err := c.httpClient.Post(c.baseURL+"/api/v1/reconcile", "application/json", nil)
+	if err != nil {
+		return ReconcileResponse{}, fmt.Errorf("connecting to server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		return ReconcileResponse{}, fmt.Errorf("server returned %d", resp.StatusCode)
+	}
+
+	var result ReconcileResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return ReconcileResponse{}, fmt.Errorf("decoding response: %w", err)
+	}
+	return result, nil
+}
+
+func (c *Client) Suspend(name string) (*server.StackState, error) {
+	resp, err := c.httpClient.Post(c.baseURL+"/api/v1/stacks/"+name+"/suspend", "application/json", nil)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("stack %q not found", name)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("server returned %d", resp.StatusCode)
+	}
+
+	var state server.StackState
+	if err := json.NewDecoder(resp.Body).Decode(&state); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	return &state, nil
+}
+
+func (c *Client) Resume(name string) (*server.StackState, error) {
+	resp, err := c.httpClient.Post(c.baseURL+"/api/v1/stacks/"+name+"/resume", "application/json", nil)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("stack %q not found", name)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("server returned %d", resp.StatusCode)
+	}
+
+	var state server.StackState
+	if err := json.NewDecoder(resp.Body).Decode(&state); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	return &state, nil
+}
+
+func (c *Client) Version() (VersionResponse, error) {
+	resp, err := c.httpClient.Get(c.baseURL + "/api/v1/version")
+	if err != nil {
+		return VersionResponse{}, fmt.Errorf("connecting to server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var result VersionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return VersionResponse{}, fmt.Errorf("decoding response: %w", err)
+	}
+	return result, nil
+}
+```
+
+- [ ] **Step 3: Implement output.go**
+
+```go
+// cmd/dockcd/output.go
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/mohitsharma44/dockcd/internal/server"
+)
+
+func useColor() bool {
+	return os.Getenv("NO_COLOR") == ""
+}
+
+func colorize(s, color string) string {
+	if !useColor() {
+		return s
+	}
+	return color + s + "\033[0m"
+}
+
+func statusIcon(status string) string {
+	switch status {
+	case "Ready":
+		return colorize("✓", "\033[32m")
+	case "Failed":
+		return colorize("✗", "\033[31m")
+	case "Suspended":
+		return colorize("⏸", "\033[33m")
+	case "Reconciling":
+		return colorize("↻", "\033[34m")
+	default:
+		return " "
+	}
+}
+
+func printStacksTable(stacks []server.StackState) {
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "NAME\tBRANCH\tSTATUS\tHEALTH\tLAST DEPLOY\tCOMMIT")
+	for _, s := range stacks {
+		lastDeploy := "--"
+		if !s.LastDeploy.IsZero() {
+			lastDeploy = s.LastDeploy.Format("2006-01-02 15:04:05")
+		}
+		commit := s.Commit
+		if len(commit) > 7 {
+			commit = commit[:7]
+		}
+		health := s.Health
+		if health == "" {
+			health = "--"
+		}
+		fmt.Fprintf(w, "%s %s\t%s\t%s\t%s\t%s\t%s\n",
+			statusIcon(s.Status), s.Name, s.Branch, s.Status, health, lastDeploy, commit)
+	}
+	w.Flush()
+}
+
+func printJSON(v any) {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	enc.Encode(v)
+}
+
+// resolveServerURL extracts --server flag or falls back to env/default.
+func resolveServerURL(args []string) string {
+	for i, arg := range args {
+		if arg == "--server" && i+1 < len(args) {
+			return args[i+1]
+		}
+		if strings.HasPrefix(arg, "--server=") {
+			return strings.TrimPrefix(arg, "--server=")
+		}
+	}
+	if url := os.Getenv("DOCKCD_SERVER"); url != "" {
+		return url
+	}
+	return "http://localhost:9092"
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7 && go test -race ./...`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7
+git add internal/client/ cmd/dockcd/output.go
+git commit -m "feat: add HTTP client package and CLI output formatting"
+```
+
+---
+
+## Task 10: Implement CLI Commands (get, reconcile, suspend, resume, logs, stats)
+
+**Files:**
+- Modify: `cmd/dockcd/get.go`
+- Modify: `cmd/dockcd/reconcile.go`
+- Modify: `cmd/dockcd/suspend.go`
+- Create: `cmd/dockcd/resume.go` (if not already a stub)
+- Modify: `cmd/dockcd/logs.go`
+- Modify: `cmd/dockcd/stats.go`
+
+### Verification Spec
+
+**Functional:**
+- `dockcd get stacks` prints table of all stacks
+- `dockcd get stacks --output json` prints JSON
+- `dockcd get stacks --watch` polls and refreshes (basic implementation)
+- `dockcd get stack <name>` prints single stack detail
+- `dockcd reconcile stack <name>` triggers async reconcile, streams SSE output by default
+- `dockcd reconcile stack <name> --no-wait` returns immediately after 202
+- `dockcd reconcile stacks` triggers full reconcile
+- `dockcd suspend stack <name>` suspends and prints updated state
+- `dockcd resume stack <name>` resumes and prints updated state
+- `dockcd logs` streams SSE logs
+- `dockcd stats` fetches /metrics and prints formatted summary
+- All commands respect `--server` flag and `DOCKCD_SERVER` env var
+- Missing subresource (e.g., `dockcd get` with no args) prints usage and exits 2
+- Server unreachable prints clear error message
+
+**Non-functional:**
+- Consistent exit codes: 0=success, 1=failure, 2=usage error
+- SSE streaming handles Ctrl+C gracefully (clean disconnect)
+- `--no-color` flag and `NO_COLOR` env var disable color everywhere
+
+---
+
+- [ ] **Step 1: Implement runGet**
+
+```go
+// cmd/dockcd/get.go
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/mohitsharma44/dockcd/internal/client"
+)
+
+func runGet(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "Usage: dockcd get <stacks|stack <name>> [flags]")
+		return 2
+	}
+
+	switch args[0] {
+	case "stacks":
+		return runGetStacks(args[1:])
+	case "stack":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "Usage: dockcd get stack <name> [flags]")
+			return 2
+		}
+		return runGetStack(args[1], args[2:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown resource: %s\nUsage: dockcd get <stacks|stack <name>>\n", args[0])
+		return 2
+	}
+}
+
+func runGetStacks(args []string) int {
+	fs := flag.NewFlagSet("get stacks", flag.ExitOnError)
+	outputFmt := fs.String("output", "table", "output format: table or json")
+	watch := fs.Bool("watch", false, "poll and refresh")
+	server := fs.String("server", resolveServerURL(nil), "dockcd server URL")
+	fs.Parse(args)
+
+	c := client.New(*server)
+
+	for {
+		stacks, err := c.GetStacks()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			return 1
+		}
+
+		if *outputFmt == "json" {
+			printJSON(stacks)
+		} else {
+			printStacksTable(stacks)
+		}
+
+		if !*watch {
+			return 0
+		}
+		time.Sleep(2 * time.Second)
+		fmt.Print("\033[2J\033[H") // clear screen
+	}
+}
+
+func runGetStack(name string, args []string) int {
+	fs := flag.NewFlagSet("get stack", flag.ExitOnError)
+	outputFmt := fs.String("output", "table", "output format: table or json")
+	server := fs.String("server", resolveServerURL(nil), "dockcd server URL")
+	fs.Parse(args)
+
+	c := client.New(*server)
+	stack, err := c.GetStack(name)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	if *outputFmt == "json" {
+		printJSON(stack)
+	} else {
+		printStacksTable([]server.StackState{*stack})
+	}
+	return 0
+}
+```
+
+- [ ] **Step 2: Implement runReconcile**
+
+```go
+// cmd/dockcd/reconcile.go
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/mohitsharma44/dockcd/internal/client"
+)
+
+func runReconcile(args []string) int {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "Usage: dockcd reconcile <stacks|stack <name>> [flags]")
+		return 2
+	}
+
+	switch args[0] {
+	case "stacks":
+		return runReconcileAll(args[1:])
+	case "stack":
+		if len(args) < 2 {
+			fmt.Fprintln(os.Stderr, "Usage: dockcd reconcile stack <name> [flags]")
+			return 2
+		}
+		return runReconcileStack(args[1], args[2:])
+	default:
+		fmt.Fprintf(os.Stderr, "unknown resource: %s\n", args[0])
+		return 2
+	}
+}
+
+func runReconcileStack(name string, args []string) int {
+	fs := flag.NewFlagSet("reconcile stack", flag.ExitOnError)
+	noWait := fs.Bool("no-wait", false, "return immediately without streaming progress")
+	server := fs.String("server", resolveServerURL(nil), "dockcd server URL")
+	fs.Parse(args)
+
+	c := client.New(*server)
+	resp, err := c.Reconcile(name)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	fmt.Printf("%s triggering reconciliation for stack %s\n",
+		colorize("►", "\033[34m"), name)
+
+	if *noWait {
+		fmt.Printf("reconcile queued: %s\n", resp.ID)
+		return 0
+	}
+
+	// TODO: Stream SSE events from /api/v1/reconcile/{id}/events
+	// For now, print the ID and return.
+	fmt.Printf("reconcile started: %s (use 'dockcd get stack %s' to check status)\n", resp.ID, name)
+	return 0
+}
+
+func runReconcileAll(args []string) int {
+	fs := flag.NewFlagSet("reconcile stacks", flag.ExitOnError)
+	noWait := fs.Bool("no-wait", false, "return immediately")
+	server := fs.String("server", resolveServerURL(nil), "dockcd server URL")
+	fs.Parse(args)
+
+	c := client.New(*server)
+	resp, err := c.ReconcileAll()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	fmt.Printf("%s triggering reconciliation for all stacks\n",
+		colorize("►", "\033[34m"))
+
+	if *noWait {
+		fmt.Printf("reconcile queued: %s\n", resp.ID)
+		return 0
+	}
+
+	fmt.Printf("reconcile started: %s\n", resp.ID)
+	return 0
+}
+```
+
+- [ ] **Step 3: Implement runSuspend and runResume**
+
+```go
+// cmd/dockcd/suspend.go
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/mohitsharma44/dockcd/internal/client"
+)
+
+func runSuspend(args []string) int {
+	if len(args) < 2 || args[0] != "stack" {
+		fmt.Fprintln(os.Stderr, "Usage: dockcd suspend stack <name> [flags]")
+		return 2
+	}
+	name := args[1]
+
+	fs := flag.NewFlagSet("suspend", flag.ExitOnError)
+	server := fs.String("server", resolveServerURL(nil), "dockcd server URL")
+	fs.Parse(args[2:])
+
+	c := client.New(*server)
+	stack, err := c.Suspend(name)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	fmt.Printf("%s stack %q suspended\n", colorize("⏸", "\033[33m"), stack.Name)
+	return 0
+}
+
+func runResume(args []string) int {
+	if len(args) < 2 || args[0] != "stack" {
+		fmt.Fprintln(os.Stderr, "Usage: dockcd resume stack <name> [flags]")
+		return 2
+	}
+	name := args[1]
+
+	fs := flag.NewFlagSet("resume", flag.ExitOnError)
+	server := fs.String("server", resolveServerURL(nil), "dockcd server URL")
+	fs.Parse(args[2:])
+
+	c := client.New(*server)
+	stack, err := c.Resume(name)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+
+	fmt.Printf("%s stack %q resumed\n", colorize("✓", "\033[32m"), stack.Name)
+	return 0
+}
+```
+
+- [ ] **Step 4: Implement runLogs and runStats (basic)**
+
+```go
+// cmd/dockcd/logs.go
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
+)
+
+func runLogs(args []string) int {
+	fs := flag.NewFlagSet("logs", flag.ExitOnError)
+	server := fs.String("server", resolveServerURL(nil), "dockcd server URL")
+	fs.Parse(args)
+
+	resp, err := http.Get(*server + "/api/v1/logs")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	defer resp.Body.Close()
+
+	// Handle Ctrl+C.
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt)
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		select {
+		case <-sig:
+			return 0
+		default:
+		}
+		line := scanner.Text()
+		if len(line) > 5 && line[:5] == "data:" {
+			fmt.Println(line[6:])
+		}
+	}
+	return 0
+}
+```
+
+```go
+// cmd/dockcd/stats.go
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+func runStats(args []string) int {
+	fs := flag.NewFlagSet("stats", flag.ExitOnError)
+	server := fs.String("server", resolveServerURL(nil), "dockcd server URL")
+	fs.Parse(args)
+
+	resp, err := http.Get(*server + "/metrics")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		return 1
+	}
+	defer resp.Body.Close()
+
+	// For now, pipe through. Can add formatting later.
+	io.Copy(os.Stdout, resp.Body)
+	return 0
+}
+```
+
+- [ ] **Step 5: Verify build**
+
+Run: `cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7 && go build ./cmd/dockcd/ && go test -race ./...`
+Expected: Build succeeds, all tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7
+git add cmd/dockcd/
+git commit -m "feat: implement CLI commands (get, reconcile, suspend, resume, logs, stats)"
+```
+
+---
+
+## Task 11: Wire Everything Together in serve.go
+
+**Files:**
+- Modify: `cmd/dockcd/serve.go`
+
+### Verification Spec
+
+**Functional:**
+- `dockcd serve` creates and wires: EventBus, Reconciler (with EventBus), Server (with Suspender, ReconcileTriggerer, EventBus)
+- Poller is passed as Suspender to Server
+- Reconciler is passed as ReconcileTriggerer to Server
+- EventBus is shared between Reconciler and Server
+- Graceful shutdown closes EventBus
+- All existing behavior preserved (flags, env vars, signal handling)
+- `-ldflags "-X main.Version=x.y.z"` sets the version for the version endpoint
+
+**Non-functional:**
+- Single clean wiring point — no circular dependencies
+- Build still works: `go build ./cmd/dockcd/`
+
+---
+
+- [ ] **Step 1: Update serve.go wiring**
+
+In `runServe()`, after creating the poller and before creating the server, create the EventBus and pass it through:
+
+```go
+// Create event bus.
+eventBus := notify.NewEventBus()
+
+// Create reconciler with event bus.
+rec, err := reconciler.New(reconciler.Config{
+	// ... existing fields ...
+	EventBus: eventBus,
+})
+
+// Create server with suspend/resume and reconcile trigger capabilities.
+srv := server.New(
+	fmt.Sprintf(":%d", *metricsPort),
+	status,
+	logger,
+	poller,   // Suspender
+	rec,      // ReconcileTriggerer
+	eventBus,
+)
+
+// In shutdown section, add:
+eventBus.Close()
+```
+
+- [ ] **Step 2: Verify full build and test suite**
+
+Run: `cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7 && go build -ldflags "-X main.Version=0.2.0" ./cmd/dockcd/ && go test -race ./...`
+Expected: Build succeeds, all tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7
+git add cmd/dockcd/serve.go
+git commit -m "feat: wire event bus, suspend/resume, and reconcile trigger into serve command"
+```
+
+---
+
+## Task 12: Integration Tests for Hooks and Suspend/Resume
+
+**Files:**
+- Modify: `internal/reconciler/reconciler_integration_test.go`
+
+### Verification Spec
+
+**Functional:**
+- Integration test: stack with pre_deploy hook — hook runs before compose, hook env vars are set
+- Integration test: pre_deploy hook failure prevents deploy
+- Integration test: suspended stack is skipped during reconcile
+- Integration test: resumed stack is deployed on next reconcile
+- Integration test: force reconcile via TriggerReconcile deploys a single stack
+
+**Non-functional:**
+- Tests use real git repos (via testutil)
+- Tests use recording runners (no real docker compose)
+- All tests pass with `-race` flag
+- Tests are tagged `//go:build integration`
+
+---
+
+- [ ] **Step 1: Write integration tests**
+
+Add to `internal/reconciler/reconciler_integration_test.go`:
+
+```go
+func TestIntegrationPreDeployHookRuns(t *testing.T) {
+	bareDir := testutil.InitBareRepo(t)
+	workDir := testutil.CloneAndSetup(t, bareDir)
+
+	// Create a stack with a hook script.
+	testutil.CommitFile(t, workDir, "stacks/web/compose.yaml",
+		"services:\n  web:\n    image: nginx", "add web stack")
+	testutil.CommitFile(t, workDir, "stacks/web/hook.sh",
+		"#!/bin/sh\necho \"HOOK: $DOCKCD_STACK_NAME $DOCKCD_COMMIT\"", "add hook")
+
+	cloneDir := filepath.Join(t.TempDir(), "dockcd-clone")
+	poller := git.NewPoller(bareDir, cloneDir)
+	poller.SetStateFile(filepath.Join(cloneDir, ".dockcd_state"))
+
+	hookTimeout := 5 * time.Second
+	stacks := []config.Stack{{
+		Name: "web",
+		Path: "stacks/web",
+		Hooks: &config.Hooks{
+			PreDeploy: &config.HookConfig{Command: "sh hook.sh", Timeout: hookTimeout},
+		},
+	}}
+
+	var mu sync.Mutex
+	var calls []deployCall
+	runner := func(ctx context.Context, dir, name string, args ...string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, deployCall{dir: dir, name: name, args: args})
+		return nil
+	}
+
+	status := &server.Status{}
+	rec, err := New(Config{
+		Poller:       poller,
+		HostStacks:   stacks,
+		Hostname:     "integration-test",
+		RepoDir:      cloneDir,
+		PollInterval: 100 * time.Millisecond,
+		Runner:       runner,
+		Status:       status,
+	})
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	if err := rec.initRepo(); err != nil {
+		t.Fatalf("initRepo failed: %v", err)
+	}
+
+	if err := rec.deployAll(context.Background()); err != nil {
+		t.Fatalf("deployAll failed: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Hook runs via sh -c (not tracked in calls). Compose pull + up = 2 calls.
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 compose calls, got %d", len(calls))
+	}
+}
+
+func TestIntegrationSuspendSkipsStack(t *testing.T) {
+	bareDir := testutil.InitBareRepo(t)
+	workDir := testutil.CloneAndSetup(t, bareDir)
+	testutil.CommitFile(t, workDir, "stacks/web/compose.yaml",
+		"services:\n  web:\n    image: nginx", "add web")
+
+	cloneDir := filepath.Join(t.TempDir(), "dockcd-clone")
+	poller := git.NewPoller(bareDir, cloneDir)
+	poller.SetStateFile(filepath.Join(cloneDir, ".dockcd_state"))
+
+	var mu sync.Mutex
+	var calls []deployCall
+	runner := func(ctx context.Context, dir, name string, args ...string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, deployCall{dir: dir, name: name, args: args})
+		return nil
+	}
+
+	status := &server.Status{}
+	rec, err := New(Config{
+		Poller:       poller,
+		HostStacks:   []config.Stack{{Name: "web", Path: "stacks/web"}},
+		Hostname:     "integration-test",
+		RepoDir:      cloneDir,
+		PollInterval: 100 * time.Millisecond,
+		Runner:       runner,
+		Status:       status,
+	})
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	if err := rec.initRepo(); err != nil {
+		t.Fatalf("initRepo failed: %v", err)
+	}
+
+	// Suspend the stack.
+	if err := poller.SuspendStack("web"); err != nil {
+		t.Fatalf("SuspendStack: %v", err)
+	}
+
+	// Push a change.
+	testutil.CommitFile(t, workDir, "stacks/web/compose.yaml",
+		"services:\n  web:\n    image: nginx:v2", "update web")
+
+	// Reconcile should skip suspended stack.
+	if err := rec.reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(calls) != 0 {
+		t.Errorf("expected 0 deploy calls for suspended stack, got %d", len(calls))
+	}
+}
+```
+
+- [ ] **Step 2: Run integration tests**
+
+Run: `cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7 && go test -tags integration -race -v ./internal/reconciler/`
+Expected: All integration tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7
+git add internal/reconciler/reconciler_integration_test.go
+git commit -m "test: add integration tests for hooks and suspend/resume"
+```
+
+---
+
+## Task 13: Update CI Pipeline for Docker Build
+
+**Files:**
+- Modify: `.github/workflows/ci.yaml`
+
+### Verification Spec
+
+**Functional:**
+- CI workflow adds a `docker build` step after tests pass
+- Build uses `docker build -t dockcd:ci .`
+- No push — build verification only
+- Build step runs on ubuntu-latest (Docker is available)
+
+**Non-functional:**
+- Existing CI steps unchanged
+- New step only runs if tests pass (sequential dependency)
+
+---
+
+- [ ] **Step 1: Add docker build step to CI**
+
+Add after the existing `Build` step in `.github/workflows/ci.yaml`:
+
+```yaml
+      - name: Docker build
+        run: docker build -t dockcd:ci .
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /Users/mohitsharma44/devel/worktrees/dockcd-planning-7e7
+git add .github/workflows/ci.yaml
+git commit -m "ci: add Docker build verification step"
+```
+
+---
+
+## Summary of tasks and dependencies
+
+```
+Task 1: Hook execution package          (independent)
+Task 2: Config changes                   (independent)
+Task 3: Hook deploy integration          (depends on 1, 2)
+Task 4: Event bus                        (independent)
+Task 5: Suspend/resume in poller         (independent)
+Task 6: Server API endpoints             (depends on 4, 5)
+Task 7: Async reconcile + events         (depends on 4, 6)
+Task 8: CLI subcommand router            (independent)
+Task 9: HTTP client + output             (depends on 6)
+Task 10: CLI command implementations     (depends on 8, 9)
+Task 11: Wire everything in serve.go     (depends on 3, 6, 7, 10)
+Task 12: Integration tests               (depends on 3, 5, 11)
+Task 13: CI Docker build                 (independent)
+```
+
+**Parallelizable groups:**
+- Group A: Tasks 1, 2, 4, 5, 8, 13 (all independent)
+- Group B: Tasks 3, 6 (after their deps)
+- Group C: Tasks 7, 9 (after group B)
+- Group D: Tasks 10, 11 (after group C)
+- Group E: Task 12 (after group D)

--- a/docs/superpowers/plans/2026-04-04-phase2-plan2-notifications-multibranch.md
+++ b/docs/superpowers/plans/2026-04-04-phase2-plan2-notifications-multibranch.md
@@ -1,0 +1,1324 @@
+# Phase 2 Plan 2: Notifications + Multi-Branch Support
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Slack + generic webhook notifications on lifecycle events, and per-stack branch override support so stacks can track branches other than the default.
+
+**Architecture:** A `Notifier` interface with two implementations (WebhookNotifier, SlackNotifier) consumes events from the existing EventBus via a Dispatcher goroutine. Multi-branch extends the Poller to track per-branch hashes and extract stack files from non-default branches via `git archive`. Both features are independent and can be implemented in parallel.
+
+**Tech Stack:** Go stdlib (`net/http`, `encoding/json`, `os/exec`), existing EventBus from `internal/notify/`, existing Poller from `internal/git/`. No new dependencies.
+
+**Conventions (read before starting any task):**
+- Follow existing patterns: table-driven tests, mock interfaces, `writeTemp` helpers
+- All tests use `-race` flag (CI enforces this)
+- Integration tests use `//go:build integration` tag
+- Error wrapping: `fmt.Errorf("context: %w", err)`
+- Structured logging via `slog`
+- Existing types: `notify.Event`, `notify.EventBus`, `config.NotificationConfig`, `git.Poller`, `git.State`
+
+---
+
+## File Map
+
+### New files
+```
+internal/notify/notifier.go          # Notifier interface, WebhookNotifier, SlackNotifier
+internal/notify/notifier_test.go     # Tests with httptest servers
+internal/notify/dispatcher.go        # Dispatcher: subscribes to EventBus, filters, routes to notifiers
+internal/notify/dispatcher_test.go   # Dispatcher tests
+```
+
+### Modified files
+```
+internal/git/poller.go               # Multi-branch state, per-branch fetch/diff, git archive extraction
+internal/git/poller_test.go          # Tests for multi-branch
+internal/config/config.go            # EffectiveBranch() helper on Stack
+internal/reconciler/reconciler.go    # Branch-aware change detection, pass branch to hooks.Env
+internal/reconciler/reconciler_test.go # Tests for branch-aware reconcile
+internal/reconciler/reconciler_integration_test.go # Integration tests for multi-branch
+cmd/dockcd/serve.go                  # Wire Dispatcher with notifiers from config
+```
+
+---
+
+## Task 1: Notifier Interface and WebhookNotifier
+
+**Files:**
+- Create: `internal/notify/notifier.go`
+- Create: `internal/notify/notifier_test.go`
+
+### Verification Spec
+
+**Functional:**
+- `Notifier` interface: `Name() string`, `Send(ctx context.Context, event Event) error`
+- `WebhookNotifier` POSTs JSON to a URL matching the generic webhook payload from the design spec
+- Payload fields: `event`, `timestamp`, `stack`, `host`, `commit`, `branch`, `message`, `metadata`
+- Returns nil on 2xx response
+- Returns error on non-2xx with status code in message
+- Returns error on network failure
+- HTTP timeout of 10 seconds per request
+
+**Non-functional:**
+- Tested with httptest (no real network)
+- Verifies request method (POST), Content-Type (application/json), and payload shape
+- Test for network error (closed server)
+- Test for non-2xx response
+
+---
+
+- [ ] **Step 1: Write failing tests for WebhookNotifier**
+
+```go
+// internal/notify/notifier_test.go
+package notify
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestWebhookNotifierSend(t *testing.T) {
+	var receivedBody map[string]any
+	var receivedMethod string
+	var receivedContentType string
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedMethod = r.Method
+		receivedContentType = r.Header.Get("Content-Type")
+		json.NewDecoder(r.Body).Decode(&receivedBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	n := NewWebhookNotifier("test-webhook", ts.URL)
+	event := Event{
+		Type:      EventDeploySuccess,
+		Timestamp: time.Date(2026, 4, 4, 12, 0, 0, 0, time.UTC),
+		Stack:     "traefik",
+		Host:      "server04",
+		Commit:    "abc123",
+		Branch:    "main",
+		Message:   "deploy succeeded",
+	}
+
+	err := n.Send(context.Background(), event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if receivedMethod != "POST" {
+		t.Errorf("expected POST, got %s", receivedMethod)
+	}
+	if receivedContentType != "application/json" {
+		t.Errorf("expected application/json, got %s", receivedContentType)
+	}
+	if receivedBody["event"] != "deploy_success" {
+		t.Errorf("expected event 'deploy_success', got %v", receivedBody["event"])
+	}
+	if receivedBody["stack"] != "traefik" {
+		t.Errorf("expected stack 'traefik', got %v", receivedBody["stack"])
+	}
+}
+
+func TestWebhookNotifierName(t *testing.T) {
+	n := NewWebhookNotifier("my-webhook", "http://example.com")
+	if n.Name() != "my-webhook" {
+		t.Errorf("expected name 'my-webhook', got %q", n.Name())
+	}
+}
+
+func TestWebhookNotifierNon2xx(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	n := NewWebhookNotifier("test", ts.URL)
+	err := n.Send(context.Background(), Event{Type: EventDeployFailure})
+	if err == nil {
+		t.Fatal("expected error for 500 response")
+	}
+}
+
+func TestWebhookNotifierNetworkError(t *testing.T) {
+	n := NewWebhookNotifier("test", "http://127.0.0.1:1") // nothing listening
+	err := n.Send(context.Background(), Event{Type: EventDeployFailure})
+	if err == nil {
+		t.Fatal("expected error for network failure")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test -race -v ./internal/notify/ -run "TestWebhook"`
+Expected: Compilation error — `NewWebhookNotifier` doesn't exist
+
+- [ ] **Step 3: Implement Notifier interface and WebhookNotifier**
+
+```go
+// internal/notify/notifier.go
+package notify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Notifier delivers events to an external system.
+type Notifier interface {
+	Name() string
+	Send(ctx context.Context, event Event) error
+}
+
+// webhookPayload is the JSON shape sent to generic webhook URLs.
+type webhookPayload struct {
+	Event     string            `json:"event"`
+	Timestamp string            `json:"timestamp"`
+	Stack     string            `json:"stack,omitempty"`
+	Host      string            `json:"host,omitempty"`
+	Commit    string            `json:"commit,omitempty"`
+	Branch    string            `json:"branch,omitempty"`
+	Message   string            `json:"message,omitempty"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+}
+
+// WebhookNotifier sends events as JSON POST requests to a URL.
+type WebhookNotifier struct {
+	name   string
+	url    string
+	client *http.Client
+}
+
+// NewWebhookNotifier creates a notifier that POSTs generic JSON to the given URL.
+func NewWebhookNotifier(name, url string) *WebhookNotifier {
+	return &WebhookNotifier{
+		name:   name,
+		url:    url,
+		client: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (w *WebhookNotifier) Name() string { return w.name }
+
+func (w *WebhookNotifier) Send(ctx context.Context, event Event) error {
+	payload := webhookPayload{
+		Event:     string(event.Type),
+		Timestamp: event.Timestamp.Format(time.RFC3339),
+		Stack:     event.Stack,
+		Host:      event.Host,
+		Commit:    event.Commit,
+		Branch:    event.Branch,
+		Message:   event.Message,
+		Metadata:  event.Metadata,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("notifier %q: marshaling payload: %w", w.name, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("notifier %q: creating request: %w", w.name, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := w.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("notifier %q: sending request: %w", w.name, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("notifier %q: server returned %d", w.name, resp.StatusCode)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test -race -v ./internal/notify/ -run "TestWebhook"`
+Expected: All 4 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/notify/notifier.go internal/notify/notifier_test.go
+git commit -m "feat: add Notifier interface and WebhookNotifier"
+```
+
+---
+
+## Task 2: SlackNotifier
+
+**Files:**
+- Modify: `internal/notify/notifier.go`
+- Modify: `internal/notify/notifier_test.go`
+
+### Verification Spec
+
+**Functional:**
+- `SlackNotifier` sends Slack Block Kit formatted payloads to a webhook URL
+- Color-coded: green for success events, red for failure, yellow for rollback/warning
+- Includes: stack name, commit (7-char), branch, host, timestamp
+- Error detail in a code block when Message is non-empty
+- Reuses the same HTTP client pattern as WebhookNotifier (10s timeout)
+
+**Non-functional:**
+- Tested with httptest verifying Slack payload structure
+- Test for each color category (success, failure, rollback)
+
+---
+
+- [ ] **Step 1: Write failing tests for SlackNotifier**
+
+```go
+// Add to internal/notify/notifier_test.go
+
+func TestSlackNotifierSend(t *testing.T) {
+	var receivedBody map[string]any
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&receivedBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	n := NewSlackNotifier("slack-test", ts.URL)
+	event := Event{
+		Type:      EventDeploySuccess,
+		Timestamp: time.Date(2026, 4, 4, 12, 0, 0, 0, time.UTC),
+		Stack:     "traefik",
+		Host:      "server04",
+		Commit:    "abc123def456",
+		Branch:    "main",
+		Message:   "deploy succeeded",
+	}
+
+	err := n.Send(context.Background(), event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Slack payload should have "attachments" array.
+	attachments, ok := receivedBody["attachments"].([]any)
+	if !ok || len(attachments) == 0 {
+		t.Fatal("expected non-empty 'attachments' in Slack payload")
+	}
+
+	att := attachments[0].(map[string]any)
+	// Success → green color.
+	if att["color"] != "good" {
+		t.Errorf("expected color 'good', got %v", att["color"])
+	}
+}
+
+func TestSlackNotifierFailureColor(t *testing.T) {
+	var receivedBody map[string]any
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&receivedBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	n := NewSlackNotifier("slack-test", ts.URL)
+	err := n.Send(context.Background(), Event{
+		Type: EventDeployFailure, Stack: "web", Message: "health check failed",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	attachments := receivedBody["attachments"].([]any)
+	att := attachments[0].(map[string]any)
+	if att["color"] != "danger" {
+		t.Errorf("expected color 'danger', got %v", att["color"])
+	}
+}
+
+func TestSlackNotifierRollbackColor(t *testing.T) {
+	var receivedBody map[string]any
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&receivedBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	n := NewSlackNotifier("slack-test", ts.URL)
+	err := n.Send(context.Background(), Event{Type: EventRollbackSuccess, Stack: "web"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	attachments := receivedBody["attachments"].([]any)
+	att := attachments[0].(map[string]any)
+	if att["color"] != "warning" {
+		t.Errorf("expected color 'warning', got %v", att["color"])
+	}
+}
+
+func TestSlackNotifierCommitTruncated(t *testing.T) {
+	var receivedBody map[string]any
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&receivedBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	n := NewSlackNotifier("slack-test", ts.URL)
+	err := n.Send(context.Background(), Event{
+		Type: EventDeploySuccess, Commit: "abcdef1234567890",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The commit in the text should be truncated to 7 chars.
+	attachments := receivedBody["attachments"].([]any)
+	att := attachments[0].(map[string]any)
+	text, _ := att["text"].(string)
+	if len(text) > 0 && !contains(text, "abcdef1") {
+		t.Errorf("expected 7-char commit in text, got %q", text)
+	}
+}
+
+// contains is a simple helper for substring matching.
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && stringContains(s, substr))
+}
+```
+
+Actually, use `strings.Contains` instead of a custom helper. Add `"strings"` import.
+
+- [ ] **Step 2: Implement SlackNotifier**
+
+Add to `internal/notify/notifier.go`:
+
+```go
+// SlackNotifier sends events as Slack-formatted webhook payloads.
+type SlackNotifier struct {
+	name   string
+	url    string
+	client *http.Client
+}
+
+// NewSlackNotifier creates a notifier that sends Slack Block Kit attachments.
+func NewSlackNotifier(name, url string) *SlackNotifier {
+	return &SlackNotifier{
+		name:   name,
+		url:    url,
+		client: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (s *SlackNotifier) Name() string { return s.name }
+
+func (s *SlackNotifier) Send(ctx context.Context, event Event) error {
+	color := slackColor(event.Type)
+	commit := event.Commit
+	if len(commit) > 7 {
+		commit = commit[:7]
+	}
+
+	text := fmt.Sprintf("*%s* | stack: `%s` | branch: `%s` | host: `%s` | commit: `%s`",
+		string(event.Type), event.Stack, event.Branch, event.Host, commit)
+
+	if event.Message != "" {
+		text += fmt.Sprintf("\n```%s```", event.Message)
+	}
+
+	payload := map[string]any{
+		"attachments": []map[string]any{
+			{
+				"color":  color,
+				"text":   text,
+				"ts":     event.Timestamp.Unix(),
+			},
+		},
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("notifier %q: marshaling slack payload: %w", s.name, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("notifier %q: creating request: %w", s.name, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("notifier %q: sending request: %w", s.name, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("notifier %q: slack returned %d", s.name, resp.StatusCode)
+	}
+	return nil
+}
+
+func slackColor(t EventType) string {
+	switch t {
+	case EventDeploySuccess, EventReconcileComplete, EventStackResumed:
+		return "good"
+	case EventDeployFailure, EventRollbackFailure, EventHookFailure:
+		return "danger"
+	case EventRollbackSuccess, EventStackSuspended, EventForceDeploy:
+		return "warning"
+	default:
+		return "#439FE0" // info blue
+	}
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `go test -race -v ./internal/notify/ -run "TestSlack"`
+Expected: All Slack tests PASS
+
+- [ ] **Step 4: Run full suite**
+
+Run: `go test -race ./...`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/notify/notifier.go internal/notify/notifier_test.go
+git commit -m "feat: add SlackNotifier with color-coded attachments"
+```
+
+---
+
+## Task 3: Notification Dispatcher
+
+**Files:**
+- Create: `internal/notify/dispatcher.go`
+- Create: `internal/notify/dispatcher_test.go`
+
+### Verification Spec
+
+**Functional:**
+- `Dispatcher` subscribes to EventBus, filters events per-notifier, and routes to the right notifiers
+- Each notifier has a configured list of event types it cares about
+- Events not in a notifier's list are skipped
+- Notification delivery is fire-and-forget (errors logged, never block deploy)
+- 3 retries with exponential backoff (1s, 2s, 4s) on send failure
+- Failed notifications increment a counter (for metrics) and log a warning
+- `Dispatcher.Start(ctx)` runs in a goroutine, stops when context is cancelled or EventBus is closed
+- `NewDispatcher(eventBus, logger, notifiers []NotifierWithFilter)` constructor
+
+**Non-functional:**
+- Thread-safe
+- No goroutine leaks: context cancellation cleans up
+- Tested without real network (mock notifiers)
+
+---
+
+- [ ] **Step 1: Write failing tests**
+
+```go
+// internal/notify/dispatcher_test.go
+package notify
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+)
+
+// mockNotifier records sent events for testing.
+type mockNotifier struct {
+	name   string
+	mu     sync.Mutex
+	events []Event
+	err    error // if set, Send returns this error
+}
+
+func (m *mockNotifier) Name() string { return m.name }
+func (m *mockNotifier) Send(_ context.Context, e Event) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.err != nil {
+		return m.err
+	}
+	m.events = append(m.events, e)
+	return nil
+}
+func (m *mockNotifier) sentEvents() []Event {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]Event, len(m.events))
+	copy(cp, m.events)
+	return cp
+}
+
+func TestDispatcherRoutesEvents(t *testing.T) {
+	bus := NewEventBus()
+	defer bus.Close()
+
+	slack := &mockNotifier{name: "slack"}
+	webhook := &mockNotifier{name: "webhook"}
+
+	d := NewDispatcher(bus, slog.Default(), []NotifierWithFilter{
+		{Notifier: slack, Events: map[EventType]bool{EventDeploySuccess: true, EventDeployFailure: true}},
+		{Notifier: webhook, Events: map[EventType]bool{EventDeployFailure: true}},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go d.Start(ctx)
+
+	// Give dispatcher time to subscribe.
+	time.Sleep(50 * time.Millisecond)
+
+	bus.Emit(Event{Type: EventDeploySuccess, Stack: "web"})
+	bus.Emit(Event{Type: EventDeployFailure, Stack: "db"})
+	bus.Emit(Event{Type: EventRollbackSuccess, Stack: "api"}) // no notifier cares
+
+	time.Sleep(100 * time.Millisecond)
+
+	slackEvents := slack.sentEvents()
+	webhookEvents := webhook.sentEvents()
+
+	if len(slackEvents) != 2 {
+		t.Errorf("slack: expected 2 events, got %d", len(slackEvents))
+	}
+	if len(webhookEvents) != 1 {
+		t.Errorf("webhook: expected 1 event, got %d", len(webhookEvents))
+	}
+	if len(webhookEvents) > 0 && webhookEvents[0].Stack != "db" {
+		t.Errorf("webhook: expected stack 'db', got %q", webhookEvents[0].Stack)
+	}
+}
+
+func TestDispatcherStopsOnContextCancel(t *testing.T) {
+	bus := NewEventBus()
+	defer bus.Close()
+
+	d := NewDispatcher(bus, slog.Default(), nil)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		d.Start(ctx)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+		// good
+	case <-time.After(time.Second):
+		t.Fatal("dispatcher did not stop after context cancel")
+	}
+}
+
+func TestDispatcherStopsOnBusClose(t *testing.T) {
+	bus := NewEventBus()
+	d := NewDispatcher(bus, slog.Default(), nil)
+
+	ctx := context.Background()
+	done := make(chan struct{})
+	go func() {
+		d.Start(ctx)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	bus.Close()
+
+	select {
+	case <-done:
+		// good
+	case <-time.After(time.Second):
+		t.Fatal("dispatcher did not stop after bus close")
+	}
+}
+
+func TestDispatcherRetriesOnFailure(t *testing.T) {
+	bus := NewEventBus()
+	defer bus.Close()
+
+	failCount := 0
+	failing := &mockNotifier{name: "failing"}
+	// First 2 calls fail, 3rd succeeds.
+	origSend := failing.Send
+	_ = origSend
+	var mu sync.Mutex
+	var attempts int
+
+	// We need a custom notifier for retry testing.
+	retryNotifier := &retryTestNotifier{failUntil: 2}
+
+	d := NewDispatcher(bus, slog.Default(), []NotifierWithFilter{
+		{Notifier: retryNotifier, Events: map[EventType]bool{EventDeployFailure: true}},
+	})
+	_ = failCount
+	_ = mu
+	_ = attempts
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go d.Start(ctx)
+
+	time.Sleep(50 * time.Millisecond)
+	bus.Emit(Event{Type: EventDeployFailure, Stack: "web"})
+
+	// Wait for retries (1s + 2s + margin).
+	time.Sleep(4 * time.Second)
+
+	if retryNotifier.successCount() != 1 {
+		t.Errorf("expected 1 successful delivery after retries, got %d", retryNotifier.successCount())
+	}
+}
+
+type retryTestNotifier struct {
+	failUntil int
+	mu        sync.Mutex
+	attempts  int
+	successes int
+}
+
+func (r *retryTestNotifier) Name() string { return "retry-test" }
+func (r *retryTestNotifier) Send(_ context.Context, _ Event) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.attempts++
+	if r.attempts <= r.failUntil {
+		return fmt.Errorf("simulated failure %d", r.attempts)
+	}
+	r.successes++
+	return nil
+}
+func (r *retryTestNotifier) successCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.successes
+}
+```
+
+- [ ] **Step 2: Implement Dispatcher**
+
+```go
+// internal/notify/dispatcher.go
+package notify
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// NotifierWithFilter pairs a Notifier with the set of event types it should receive.
+type NotifierWithFilter struct {
+	Notifier Notifier
+	Events   map[EventType]bool
+}
+
+// Dispatcher subscribes to an EventBus and routes events to notifiers
+// based on per-notifier event filters.
+type Dispatcher struct {
+	bus       *EventBus
+	logger    *slog.Logger
+	notifiers []NotifierWithFilter
+}
+
+// NewDispatcher creates a Dispatcher. Call Start() to begin consuming events.
+func NewDispatcher(bus *EventBus, logger *slog.Logger, notifiers []NotifierWithFilter) *Dispatcher {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Dispatcher{bus: bus, logger: logger, notifiers: notifiers}
+}
+
+// Start subscribes to the EventBus and dispatches events to matching notifiers.
+// It blocks until ctx is cancelled or the EventBus is closed.
+func (d *Dispatcher) Start(ctx context.Context) {
+	ch := d.bus.Subscribe()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event, ok := <-ch:
+			if !ok {
+				return // bus closed
+			}
+			d.dispatch(ctx, event)
+		}
+	}
+}
+
+func (d *Dispatcher) dispatch(ctx context.Context, event Event) {
+	for _, nf := range d.notifiers {
+		if !nf.Events[event.Type] {
+			continue
+		}
+		// Fire-and-forget with retries.
+		go d.sendWithRetry(ctx, nf.Notifier, event)
+	}
+}
+
+// sendWithRetry attempts to send with 3 retries and exponential backoff.
+func (d *Dispatcher) sendWithRetry(ctx context.Context, n Notifier, event Event) {
+	backoff := []time.Duration{0, 1 * time.Second, 2 * time.Second, 4 * time.Second}
+
+	for attempt := 0; attempt < len(backoff); attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(backoff[attempt]):
+			}
+		}
+
+		if err := n.Send(ctx, event); err != nil {
+			d.logger.Warn("notification send failed",
+				"notifier", n.Name(),
+				"event", string(event.Type),
+				"attempt", attempt+1,
+				"error", err,
+			)
+			continue
+		}
+		return // success
+	}
+	d.logger.Error("notification delivery failed after retries",
+		"notifier", n.Name(),
+		"event", string(event.Type),
+		"stack", event.Stack,
+	)
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `go test -race -v ./internal/notify/`
+Expected: All tests PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/notify/dispatcher.go internal/notify/dispatcher_test.go
+git commit -m "feat: add notification Dispatcher with retry and event filtering"
+```
+
+---
+
+## Task 4: Wire Notifications in serve.go
+
+**Files:**
+- Modify: `cmd/dockcd/serve.go`
+
+### Verification Spec
+
+**Functional:**
+- After loading config and creating EventBus, instantiate notifiers from `cfg.Notifications`
+- For each notification config: create WebhookNotifier or SlackNotifier based on `Type`
+- Build `NotifierWithFilter` with the configured event list
+- Create Dispatcher and start it in a goroutine
+- Graceful shutdown: context cancel stops the dispatcher
+
+**Non-functional:**
+- Zero notifiers configured → no dispatcher started (no-op)
+- Build still works, all tests pass
+
+---
+
+- [ ] **Step 1: Add notifier wiring to serve.go**
+
+After the EventBus creation and before creating the reconciler, add:
+
+```go
+// Build notifiers from config.
+var notifierFilters []notify.NotifierWithFilter
+for _, nc := range cfg.Notifications {
+	var n notify.Notifier
+	switch nc.Type {
+	case "slack":
+		n = notify.NewSlackNotifier(nc.Name, nc.URL)
+	case "webhook":
+		n = notify.NewWebhookNotifier(nc.Name, nc.URL)
+	}
+	events := make(map[notify.EventType]bool, len(nc.Events))
+	for _, e := range nc.Events {
+		events[notify.EventType(e)] = true
+	}
+	notifierFilters = append(notifierFilters, notify.NotifierWithFilter{
+		Notifier: n,
+		Events:   events,
+	})
+}
+
+// Start notification dispatcher if any notifiers configured.
+if len(notifierFilters) > 0 {
+	dispatcher := notify.NewDispatcher(eventBus, logger, notifierFilters)
+	go dispatcher.Start(ctx)
+	logger.Info("notification dispatcher started", "notifiers", len(notifierFilters))
+}
+```
+
+The `ctx` here is the signal context, so dispatcher stops on SIGINT/SIGTERM.
+
+- [ ] **Step 2: Verify build and tests**
+
+Run: `go build ./cmd/dockcd/ && go test -race ./...`
+Expected: Build succeeds, all tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/dockcd/serve.go
+git commit -m "feat: wire notification dispatcher from config into serve startup"
+```
+
+---
+
+## Task 5: Multi-Branch State and Polling
+
+**Files:**
+- Modify: `internal/git/poller.go`
+- Modify: `internal/git/poller_test.go`
+- Modify: `internal/config/config.go`
+
+### Verification Spec
+
+**Functional:**
+- `State` struct gains `Branches map[string]string` field (branch → last-seen hash)
+- `LastSuccessfulCommits` values change from `string` to `struct{Branch, Commit string}`
+- `Poller` gains `SetTrackedBranches(branches []string)` to configure which branches to poll
+- `Poller.Fetch()` becomes branch-aware: fetches all, diffs each tracked branch independently
+- `Poller.FetchBranch(branch string) (changed bool, err error)` — fetch and diff a single branch
+- `Poller.ChangedStacks` gains a `branch string` parameter to filter by branch
+- `Poller.LastHashForBranch(branch string) string` — returns last hash for a specific branch
+- For non-default branches: `Poller.ExtractBranchFiles(branch, stackPath, destDir string) error` uses `git archive` to extract files
+- Backward compat: state file without `branches` field migrates on load (uses `last_hash` as the default branch hash)
+- `config.Stack` gains `EffectiveBranch(defaultBranch string) string` helper
+
+**Non-functional:**
+- All state mutations under existing mutex
+- Existing tests still pass
+- New tests for multi-branch scenarios
+
+**Edge cases:**
+- Single branch (existing behavior, no regression)
+- Two branches tracked, only one has changes
+- State file migration from old format
+
+---
+
+- [ ] **Step 1: Add EffectiveBranch to config.Stack**
+
+Add to `internal/config/config.go`:
+
+```go
+// EffectiveBranch returns the branch this stack tracks.
+// Falls back to defaultBranch if not explicitly set.
+func (s *Stack) EffectiveBranch(defaultBranch string) string {
+	if s.Branch != "" {
+		return s.Branch
+	}
+	return defaultBranch
+}
+```
+
+- [ ] **Step 2: Write failing tests for multi-branch poller**
+
+Add to `internal/git/poller_test.go`:
+
+```go
+func TestLastHashForBranch(t *testing.T) {
+	dir := t.TempDir()
+	stateFile := filepath.Join(dir, ".dockcd_state")
+
+	p := NewPoller("", dir)
+	p.SetStateFile(stateFile)
+	p.lastHash = "abc123"
+	p.state.Branches = map[string]string{"main": "aaa", "canary": "bbb"}
+
+	if got := p.LastHashForBranch("main"); got != "aaa" {
+		t.Errorf("expected 'aaa', got %q", got)
+	}
+	if got := p.LastHashForBranch("canary"); got != "bbb" {
+		t.Errorf("expected 'bbb', got %q", got)
+	}
+	if got := p.LastHashForBranch("unknown"); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestSetTrackedBranches(t *testing.T) {
+	dir := t.TempDir()
+	p := NewPoller("", dir)
+	p.SetTrackedBranches([]string{"main", "canary"})
+
+	if len(p.trackedBranches) != 2 {
+		t.Fatalf("expected 2 tracked branches, got %d", len(p.trackedBranches))
+	}
+}
+
+func TestStateMigrationAddsBranches(t *testing.T) {
+	dir := t.TempDir()
+	stateFile := filepath.Join(dir, ".dockcd_state")
+
+	// Write old-format state without branches field.
+	data := `{"last_hash":"abc123","last_successful_commits":{"web":"abc123"}}`
+	if err := os.WriteFile(stateFile, []byte(data), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := NewPoller("", dir)
+	p.SetStateFile(stateFile)
+	p.branch = "main"
+	if err := p.LoadState(); err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+
+	// After migration, Branches should contain the default branch hash.
+	if p.state.Branches == nil {
+		t.Fatal("expected Branches to be initialized after migration")
+	}
+	if p.state.Branches["main"] != "abc123" {
+		t.Errorf("expected Branches[main]='abc123', got %q", p.state.Branches["main"])
+	}
+}
+```
+
+- [ ] **Step 3: Implement multi-branch state in Poller**
+
+Modify `internal/git/poller.go`:
+
+Add to `State` struct:
+```go
+type State struct {
+	LastHash              string            `json:"last_hash"`
+	Branches              map[string]string `json:"branches,omitempty"`
+	LastSuccessfulCommits map[string]string `json:"last_successful_commits"`
+	SuspendedStacks       []string          `json:"suspended_stacks,omitempty"`
+}
+```
+
+Add to `Poller` struct:
+```go
+trackedBranches []string // branches to poll (from stack configs)
+```
+
+Add methods:
+```go
+func (p *Poller) SetTrackedBranches(branches []string) {
+	p.trackedBranches = branches
+}
+
+func (p *Poller) LastHashForBranch(branch string) string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.state.Branches == nil {
+		return ""
+	}
+	return p.state.Branches[branch]
+}
+```
+
+Update `LoadState()` to migrate — after loading, if `Branches` is nil and `LastHash` is set:
+```go
+if p.state.Branches == nil && p.lastHash != "" && p.branch != "" {
+	p.state.Branches = map[string]string{p.branch: p.lastHash}
+}
+if p.state.Branches == nil {
+	p.state.Branches = make(map[string]string)
+}
+```
+
+Add `ExtractBranchFiles`:
+```go
+// ExtractBranchFiles extracts files for a stack on a non-default branch
+// using git archive, writing to destDir.
+func (p *Poller) ExtractBranchFiles(branch, stackPath, destDir string) error {
+	cmd := exec.Command("git", "archive", "--format=tar", "origin/"+branch, stackPath)
+	cmd.Dir = p.localDir
+	tarOut, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("git archive origin/%s %s: %w", branch, stackPath, err)
+	}
+
+	// Extract tar to destDir.
+	tarCmd := exec.Command("tar", "xf", "-", "--strip-components="+fmt.Sprint(strings.Count(stackPath, "/")+1))
+	tarCmd.Dir = destDir
+	tarCmd.Stdin = bytes.NewReader(tarOut)
+	if out, err := tarCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("extracting archive: %w\n%s", err, out)
+	}
+	return nil
+}
+```
+
+You'll need to add `"bytes"` to imports.
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test -race -v ./internal/git/ && go test -race -v ./internal/config/`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/git/poller.go internal/git/poller_test.go internal/config/config.go
+git commit -m "feat: add multi-branch state tracking and git archive extraction"
+```
+
+---
+
+## Task 6: Branch-Aware Reconciler
+
+**Files:**
+- Modify: `internal/reconciler/reconciler.go`
+- Modify: `internal/reconciler/reconciler_test.go`
+
+### Verification Spec
+
+**Functional:**
+- Reconciler resolves each stack's effective branch using `config.Stack.EffectiveBranch(cfg.Branch)`
+- `buildStackPaths` groups stacks by branch
+- During reconcile, the poller is asked for changed stacks per branch
+- Stacks on non-default branches get their files extracted via `ExtractBranchFiles` to a temp dir before deploy
+- Stacks on the default branch use the working tree as before (no change)
+- `hooks.Env.Branch` is populated with the stack's effective branch
+
+**Non-functional:**
+- Existing single-branch behavior is a regression-free pass-through
+- Tests for: default branch (no change), override branch stack
+
+---
+
+- [ ] **Step 1: Write failing test for branch-aware reconcile**
+
+Add to `internal/reconciler/reconciler_test.go`:
+
+```go
+func TestFilterChangedStacksPopulatesBranch(t *testing.T) {
+	stacks := []config.Stack{
+		{Name: "traefik", Path: "server04/traefik", Branch: "canary"},
+		{Name: "vault", Path: "server04/vault"},
+	}
+
+	poller := &mockPoller{lastHash: "abc123"}
+	r, _ := testReconciler(t, poller, stacks, nil)
+
+	// Both changed.
+	result := r.filterChangedStacks([]string{"traefik", "vault"})
+
+	for _, ds := range result {
+		switch ds.Name {
+		case "traefik":
+			// Should have canary branch propagated (but branch is on hooks.Env, not deploy.Stack directly).
+			// The key thing: traefik should still be in the result set.
+		case "vault":
+			// default branch
+		default:
+			t.Errorf("unexpected stack: %s", ds.Name)
+		}
+	}
+	if len(result) != 2 {
+		t.Fatalf("expected 2 stacks, got %d", len(result))
+	}
+}
+```
+
+- [ ] **Step 2: Update reconciler to populate Branch in hooks.Env**
+
+In `internal/reconciler/reconciler.go`, update `deployStack()`:
+
+```go
+func (r *Reconciler) deployStack(ctx context.Context, stack deploy.Stack, commitHash string) error {
+	// Resolve the effective branch for this stack.
+	branch := r.resolveStackBranch(stack.Name)
+
+	env := hooks.Env{
+		StackName: stack.Name,
+		Commit:    commitHash,
+		RepoDir:   r.repoDir,
+		Branch:    branch,
+	}
+	// ... rest unchanged
+```
+
+Add helper:
+```go
+func (r *Reconciler) resolveStackBranch(stackName string) string {
+	for _, cs := range r.hostStacks {
+		if cs.Name == stackName {
+			return cs.EffectiveBranch(r.defaultBranch)
+		}
+	}
+	return r.defaultBranch
+}
+```
+
+Add `defaultBranch` field to `Config` and `Reconciler`:
+```go
+// In Config:
+DefaultBranch string
+
+// In Reconciler:
+defaultBranch string
+```
+
+Wire in `New()`.
+
+- [ ] **Step 3: Update serve.go to pass DefaultBranch**
+
+In `cmd/dockcd/serve.go`, add `DefaultBranch: cfg.Branch` to the reconciler config.
+
+- [ ] **Step 4: Run full suite**
+
+Run: `go test -race ./...`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/reconciler/ cmd/dockcd/serve.go
+git commit -m "feat: branch-aware reconciler with per-stack branch resolution"
+```
+
+---
+
+## Task 7: Multi-Branch Integration Tests
+
+**Files:**
+- Modify: `internal/reconciler/reconciler_integration_test.go`
+
+### Verification Spec
+
+**Functional:**
+- Integration test: stack on default branch deploys normally (regression)
+- Integration test: stack with branch override — verify branch is resolved
+
+**Non-functional:**
+- Tests pass with `-race` and `//go:build integration`
+- Uses real git repos via testutil
+
+---
+
+- [ ] **Step 1: Write integration test for branch in hooks.Env**
+
+```go
+func TestIntegrationBranchPassedToHookEnv(t *testing.T) {
+	bareDir := testutil.InitBareRepo(t)
+	workDir := testutil.CloneAndSetup(t, bareDir)
+	testutil.CommitFile(t, workDir, "stacks/web/compose.yaml",
+		"services:\n  web:\n    image: nginx", "add web stack")
+	// Create a hook that writes the branch to a file.
+	testutil.CommitFile(t, workDir, "stacks/web/branch-hook.sh",
+		"#!/bin/sh\necho $DOCKCD_BRANCH > /tmp/dockcd-test-branch-"+t.Name(), "add branch hook")
+
+	cloneDir := filepath.Join(t.TempDir(), "dockcd-clone")
+	poller := git.NewPoller(bareDir, cloneDir)
+	poller.SetStateFile(filepath.Join(cloneDir, ".dockcd_state"))
+
+	hookTimeout := 5 * time.Second
+	stacks := []config.Stack{{
+		Name:   "web",
+		Path:   "stacks/web",
+		Branch: "main", // explicit branch
+		Hooks: &config.Hooks{
+			PreDeploy: &config.HookConfig{Command: "sh branch-hook.sh", Timeout: hookTimeout},
+		},
+	}}
+
+	var mu sync.Mutex
+	var calls []deployCall
+	runner := func(ctx context.Context, dir, name string, args ...string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, deployCall{dir: dir, name: name, args: args})
+		return nil
+	}
+
+	status := &server.Status{}
+	rec, err := New(Config{
+		Poller:        poller,
+		HostStacks:    stacks,
+		Hostname:      "integration-test",
+		RepoDir:       cloneDir,
+		PollInterval:  100 * time.Millisecond,
+		DefaultBranch: "main",
+		Runner:        runner,
+		Status:        status,
+	})
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	if err := rec.initRepo(); err != nil {
+		t.Fatalf("initRepo failed: %v", err)
+	}
+
+	if err := rec.deployAll(context.Background()); err != nil {
+		t.Fatalf("deployAll failed: %v", err)
+	}
+
+	// Verify the hook wrote the branch name.
+	branchFile := "/tmp/dockcd-test-branch-" + t.Name()
+	defer os.Remove(branchFile)
+	data, err := os.ReadFile(branchFile)
+	if err != nil {
+		t.Fatalf("reading branch file: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "main" {
+		t.Errorf("expected branch 'main', got %q", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run integration tests**
+
+Run: `go test -tags integration -race -v ./internal/reconciler/`
+Expected: All tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/reconciler/reconciler_integration_test.go
+git commit -m "test: add integration test for branch propagation to hook env"
+```
+
+---
+
+## Summary of tasks and dependencies
+
+```
+Task 1: WebhookNotifier            (independent)
+Task 2: SlackNotifier              (depends on 1 — same file)
+Task 3: Dispatcher                 (depends on 1)
+Task 4: Wire notifications         (depends on 2, 3)
+Task 5: Multi-branch poller        (independent)
+Task 6: Branch-aware reconciler    (depends on 5)
+Task 7: Integration tests          (depends on 4, 6)
+```
+
+**Parallelizable groups:**
+- Group A: Tasks 1, 5 (independent)
+- Group B: Tasks 2, 3 (after Task 1); Task 6 (after Task 5)
+- Group C: Task 4 (after 2, 3)
+- Group D: Task 7 (after 4, 6)

--- a/docs/superpowers/specs/2026-04-04-dockcd-phase2-design.md
+++ b/docs/superpowers/specs/2026-04-04-dockcd-phase2-design.md
@@ -1,0 +1,512 @@
+# dockcd Phase 2 Design Spec
+
+**Date:** 2026-04-04
+**Status:** Draft
+**Scope:** Hooks, CLI, notifications, multi-branch, trace spans, Dockerfile CI
+
+---
+
+## 1. Priority Tiers
+
+| Tier | Feature |
+|------|---------|
+| Must have | Pre/post deploy hooks (SOPS via hooks), CLI + API surface, force-deploy |
+| Should have | Slack + webhook notifications, multi-branch support |
+| Nice to have | Dockerfile CI testing, OpenTelemetry trace spans |
+
+---
+
+## 2. Config Changes
+
+The `gitops.yaml` config expands with hooks, notifications, per-stack branch overrides, and env var substitution for sensitive values.
+
+```yaml
+repo: git@github.com:user/homeops.git
+base_path: docker/stacks
+branch: main
+
+notifications:
+  - name: slack-alerts
+    type: slack
+    url: "${SLACK_WEBHOOK_URL}"
+    events:
+      - deploy_success
+      - deploy_failure
+      - rollback_success
+      - rollback_failure
+      - reconcile_start
+      - reconcile_complete
+      - force_deploy
+      - stack_suspended
+      - stack_resumed
+      - hook_failure
+  - name: generic-webhook
+    type: webhook
+    url: "${WEBHOOK_URL}"
+    events:
+      - deploy_failure
+      - rollback_failure
+
+hosts:
+  server04:
+    stacks:
+      - name: traefik
+        path: server04/traefik
+        branch: canary
+        depends_on: []
+        auto_rollback: true
+        health_check_timeout: 60s
+        post_deploy_delay: 30s
+        hooks:
+          pre_deploy:
+            command: "sops-decrypt.sh"
+            timeout: 30s
+          post_deploy:
+            command: "verify-routes.sh"
+            timeout: 30s
+```
+
+### Env var substitution
+
+All string values in config support `${VAR}` expansion via `os.ExpandEnv` at load time. Sensitive values (webhook URLs) are stored in environment variables, sourced from systemd `EnvironmentFile=`, container env, or a SOPS-decrypted `.env` on the host.
+
+### Validation additions
+
+- `notifications[].type` must be `slack` or `webhook`
+- `notifications[].events` must be valid event type enums
+- `notifications[].url` must be non-empty after env var expansion
+- `hooks.pre_deploy.command` and `hooks.post_deploy.command` must be non-empty strings if the hook block is present
+- `hooks.*.timeout` defaults to 30s, must be positive duration
+- `branch` per-stack defaults to top-level `branch`, which defaults to repo's default branch
+
+---
+
+## 3. Pre/Post Deploy Hooks
+
+### Lifecycle
+
+```
+pre_deploy hook -> docker compose pull -> docker compose up -d -> post_deploy hook -> health check
+```
+
+### Execution model
+
+- Hooks run via `sh -c <command>` with working directory set to the stack's path in the repo clone
+- Environment variables injected: `DOCKCD_STACK_NAME`, `DOCKCD_COMMIT`, `DOCKCD_REPO_DIR`, `DOCKCD_BRANCH`
+- Hooks inherit the dockcd process environment (e.g., `SOPS_AGE_KEY_FILE`)
+- Stdout/stderr captured and logged (info for stdout, warn for stderr)
+- Configurable timeout per hook, default 30s
+
+### Failure behavior
+
+- **Pre-deploy failure** (non-zero exit): skip deploy, mark stack failed, emit `hook_failure` event, notify
+- **Post-deploy failure**: log warning, emit `hook_failure` event, notify, but do NOT rollback (compose is already running)
+
+### Rollback interaction
+
+- Pre-deploy hooks run again during rollback (the old commit's stack dir may also need SOPS decryption)
+- Hooks must be idempotent
+
+### SOPS integration
+
+dockcd does not know about SOPS. The `sops-decrypt.sh` hook (user-provided) handles decryption:
+
+```bash
+#!/bin/bash
+export SOPS_AGE_KEY_FILE="${SOPS_AGE_KEY_FILE:-/etc/sops/age/keys.txt}"
+for f in *.sops.env; do
+    [ -f "$f" ] && sops -d "$f" > "${f/.sops.env/.env}"
+done
+for f in *.sops.json; do
+    [ -f "$f" ] && sops -d "$f" > "${f/.sops.json/.json}"
+done
+```
+
+Decrypted files are left in place (option A). The repo clone directory is permission-restricted (0700, dockcd user). This mirrors Flux's approach where decrypted secrets exist in-cluster guarded by RBAC.
+
+Requirements: `sops` and `age` must be installed on the host (or in the dockcd container image).
+
+---
+
+## 4. CLI + API Surface
+
+### Single binary, subcommand model
+
+`dockcd` is one binary. `dockcd serve` (or no subcommand for backward compat) runs the daemon. All other subcommands are CLI clients that talk to the server over HTTP.
+
+### Command structure
+
+Follows Flux's `<verb> <resource> [name]` pattern:
+
+| Command | API Endpoint | Method | Description |
+|---------|-------------|--------|-------------|
+| `dockcd serve` | -- | -- | Start daemon |
+| `dockcd get stacks` | `GET /api/v1/stacks` | GET | List all stacks with status |
+| `dockcd get stack <name>` | `GET /api/v1/stacks/{name}` | GET | Single stack detail |
+| `dockcd reconcile stacks` | `POST /api/v1/reconcile` | POST | Force reconcile all (async) |
+| `dockcd reconcile stack <name>` | `POST /api/v1/reconcile/{name}` | POST | Force reconcile one (async) |
+| `dockcd suspend stack <name>` | `POST /api/v1/stacks/{name}/suspend` | POST | Pause reconciliation |
+| `dockcd resume stack <name>` | `POST /api/v1/stacks/{name}/resume` | POST | Resume reconciliation |
+| `dockcd logs` | `GET /api/v1/logs` | GET (SSE) | Stream server logs |
+| `dockcd stats` | `GET /metrics` | GET | Formatted metrics summary |
+| `dockcd version` | `GET /api/v1/version` | GET | Client + server version |
+
+### CLI connection
+
+- `--server` flag, defaults to `http://localhost:9092`
+- `DOCKCD_SERVER` env var as fallback
+- No auth
+
+### Reconcile UX (Flux-style streaming)
+
+Reconcile is async on the server. The CLI opens an SSE connection to stream progress:
+
+```
+$ dockcd reconcile stack traefik
+> triggering reconciliation for stack traefik
+OK pull complete (abc123f -> def456a)
+*  running pre-deploy hook: sops-decrypt.sh
+OK pre-deploy hook completed
+*  deploying traefik
+OK health check passed
+OK reconciliation finished in 34s
+```
+
+Error case:
+```
+$ dockcd reconcile stack traefik
+> triggering reconciliation for stack traefik
+OK pull complete (abc123f -> def456a)
+*  deploying traefik
+X  health check failed: container traefik-proxy unhealthy after 60s
+*  rolling back to abc123f
+OK rollback successful
+X  reconciliation failed (rolled back)
+```
+
+Flags:
+- `--no-wait` — return 202 immediately without streaming
+- `--timeout` — max wait time (default 5m)
+
+### Get stacks output
+
+```
+NAME         BRANCH   STATUS       HEALTH    LAST DEPLOY           COMMIT
+traefik      main     Ready        Healthy   2026-04-04 12:00:00   abc123f
+vaultwarden  canary   Ready        Healthy   2026-04-04 11:45:00   def456a
+frigate      main     Suspended    --        2026-04-04 10:30:00   789beef
+alloy        main     Failed       Degraded  2026-04-04 09:15:00   ccc0000
+```
+
+- Unicode status indicators in color: `✓` green (Ready), `✗` red (Failed), `⏸` yellow (Suspended), `↻` blue (Reconciling)
+- `--output json` for machine-readable output
+- `--watch` polls and refreshes the table
+- `--no-color` disables color (respects `NO_COLOR` env var)
+- `--host` filters stacks by host
+
+### Exit codes
+
+- 0: success
+- 1: failure (deploy failed, stack not found, etc.)
+- 2: usage error (bad flags, missing args)
+
+### Backward compatibility
+
+Running `dockcd` with no args starts the daemon (current behavior). Existing systemd units and Dockerfiles continue to work unchanged.
+
+---
+
+## 5. Server API Details
+
+### Async reconcile
+
+```
+POST /api/v1/reconcile/traefik
+-> 202 Accepted
+{
+  "id": "rec-1712234567",
+  "status": "queued",
+  "stack": "traefik"
+}
+```
+
+Progress streamed via SSE:
+```
+GET /api/v1/reconcile/rec-1712234567/events
+-> Content-Type: text/event-stream
+
+data: {"type": "pull_complete", "old_commit": "abc123", "new_commit": "def456"}
+data: {"type": "hook_start", "hook": "pre_deploy", "command": "sops-decrypt.sh"}
+data: {"type": "hook_complete", "hook": "pre_deploy"}
+data: {"type": "deploy_start", "stack": "traefik"}
+data: {"type": "health_check_passed", "stack": "traefik"}
+data: {"type": "complete", "status": "success", "duration_seconds": 34}
+```
+
+### Stacks endpoint
+
+```
+GET /api/v1/stacks
+-> 200 OK
+{
+  "stacks": [
+    {
+      "name": "traefik",
+      "host": "server04",
+      "branch": "main",
+      "status": "Ready",
+      "health": "Healthy",
+      "last_deploy": "2026-04-04T12:00:00Z",
+      "commit": "abc123f",
+      "suspended": false
+    }
+  ]
+}
+```
+
+### Suspend / resume
+
+```
+POST /api/v1/stacks/traefik/suspend -> 200 OK
+POST /api/v1/stacks/traefik/resume  -> 200 OK
+```
+
+Both return the updated stack object.
+
+### Version
+
+```
+GET /api/v1/version
+-> 200 OK
+{
+  "server": "0.2.0",
+  "go": "go1.25"
+}
+```
+
+CLI prints: `dockcd client: 0.2.0, server: 0.2.0`
+
+### Logs streaming
+
+```
+GET /api/v1/logs
+-> Content-Type: text/event-stream
+
+data: {"timestamp": "...", "level": "info", "msg": "polling repo", ...}
+data: {"timestamp": "...", "level": "info", "msg": "deploying traefik", ...}
+```
+
+The server adds an slog handler that tees log records to an internal ring buffer. SSE clients consume from this buffer.
+
+### Existing endpoints unchanged
+
+- `GET /healthz` — health check (unchanged)
+- `GET /metrics` — Prometheus metrics (unchanged)
+
+---
+
+## 6. Notification System
+
+### Architecture
+
+```
+Deploy pipeline events
+        |
+  EventBus (channel)
+        |
+  Dispatcher (goroutine)
+        |
+  +-------------+
+  | Filter by   |
+  | event type  |
+  +------+------+
+         |---> SlackNotifier.Send(event)   -> Slack Block Kit POST
+         +---> WebhookNotifier.Send(event) -> Generic JSON POST
+```
+
+### Event types (enum)
+
+- `deploy_success`
+- `deploy_failure`
+- `rollback_success`
+- `rollback_failure`
+- `reconcile_start`
+- `reconcile_complete`
+- `force_deploy`
+- `stack_suspended`
+- `stack_resumed`
+- `hook_failure`
+
+### Notifier interface
+
+```go
+type Event struct {
+    Type      EventType
+    Timestamp time.Time
+    Stack     string
+    Host      string
+    Commit    string
+    Branch    string
+    Message   string
+    Metadata  map[string]string
+}
+
+type Notifier interface {
+    Name() string
+    Send(ctx context.Context, event Event) error
+}
+```
+
+### Generic webhook payload
+
+```json
+{
+  "event": "deploy_failure",
+  "timestamp": "2026-04-04T12:00:00Z",
+  "stack": "traefik",
+  "host": "server04",
+  "commit": "abc123",
+  "branch": "main",
+  "message": "health check timed out after 60s",
+  "metadata": {}
+}
+```
+
+### Slack formatting
+
+- Color-coded attachments: green (success), red (failure), yellow (rollback/warning)
+- Stack name, commit (short hash), branch, host, timestamp
+- Error detail in a code block when applicable
+- Posted as Slack Block Kit payload to the webhook URL
+
+### Delivery guarantees
+
+- Fire-and-forget goroutine per notification (never blocks deploy pipeline)
+- 3 retries with exponential backoff (1s, 2s, 4s) on HTTP failure
+- Failed notifications increment `dockcd_notification_failures_total` metric and log a warning
+- Notification errors never fail a deploy
+
+---
+
+## 7. Multi-Branch Polling
+
+### Config
+
+Per-stack `branch` field, defaults to top-level `branch`, which defaults to the repo's default branch.
+
+### Poller changes
+
+- Poller discovers all unique branches referenced by stack configs
+- `git fetch origin` fetches all remote branches (already does this)
+- Diff runs per unique branch: `git diff <last_hash> origin/<branch> --name-only`
+- Changed stacks are matched against their configured branch
+
+### File access at deploy time
+
+- Working tree stays on the default branch
+- For stacks on the default branch: files read directly from working tree (current behavior)
+- For stacks on override branches: `git archive origin/<branch> -- <stack_path>` extracts to a temp directory at deploy time
+
+### State file changes
+
+```json
+{
+  "branches": {
+    "main": "abc123",
+    "canary": "def456"
+  },
+  "last_successful_commits": {
+    "traefik": {
+      "branch": "main",
+      "commit": "abc123"
+    },
+    "vaultwarden": {
+      "branch": "canary",
+      "commit": "def456"
+    }
+  },
+  "suspended_stacks": ["frigate"]
+}
+```
+
+### Backward compatibility
+
+The state file reader detects the old format (single `last_hash` string or flat `last_successful_commits`) and auto-migrates to the new structure on next write.
+
+---
+
+## 8. Suspend / Resume
+
+- Suspension state persisted in the state file (`suspended_stacks` array)
+- Suspended stacks are skipped during reconciliation (poll still happens, changes are detected but not deployed)
+- When resumed, the stack is marked as "needs reconcile" internally. The next poll cycle deploys it regardless of whether the branch hash has changed (to catch changes that occurred while suspended). After that first reconcile, normal change-detection resumes. Alternatively, the user can `dockcd reconcile stack <name>` to force it immediately.
+- Suspending an already-suspended stack is a no-op (200 OK)
+- Resuming a non-suspended stack is a no-op (200 OK)
+
+---
+
+## 9. OpenTelemetry Trace Spans
+
+The OTel tracing infrastructure is already wired (gRPC exporter, service name, noop fallback). Add spans to key operations:
+
+- `reconcile` — root span per reconcile cycle
+- `git.fetch` — git fetch + diff
+- `deploy.stack` — per-stack deploy (child of reconcile)
+- `hook.pre_deploy` / `hook.post_deploy` — per-hook execution
+- `health_check` — per-stack health check
+- `rollback` — rollback operation
+- `notification.send` — per-notification delivery
+
+Span attributes: `stack.name`, `stack.branch`, `commit`, `host`, `hook.command`, `notification.type`.
+
+---
+
+## 10. Dockerfile CI
+
+Add a `docker build` step to `.github/workflows/ci.yaml`:
+
+```yaml
+- name: Docker build
+  run: docker build -t dockcd:ci .
+```
+
+Runs after tests pass. Validates the multi-stage build compiles and produces a valid image. No push — just build verification.
+
+The Dockerfile will also need updating to include `sops` and `age` binaries if the container image is the deployment target (matching the Periphery pattern). This is optional — users can also install sops on the host and run dockcd via systemd.
+
+---
+
+## 11. Package / File Layout
+
+### New packages
+
+```
+internal/hooks/         # Hook execution (sh -c, timeout, env vars)
+internal/notify/        # EventBus, Notifier interface, SlackNotifier, WebhookNotifier
+internal/client/        # HTTP client for CLI commands
+```
+
+### Modified packages
+
+```
+internal/config/        # New fields: hooks, notifications, branch
+internal/git/           # Multi-branch tracking, state file changes
+internal/deploy/        # Hook integration in deploy lifecycle
+internal/reconciler/    # Event emission, suspend/resume, async reconcile
+internal/server/        # New API endpoints, SSE streaming, log tee
+cmd/dockcd/             # Subcommand router, CLI commands
+```
+
+### New files in cmd/dockcd/
+
+```
+cmd/dockcd/main.go      # Refactored: subcommand router
+cmd/dockcd/serve.go     # Daemon startup (extracted from current main.go)
+cmd/dockcd/reconcile.go # CLI: reconcile stack(s)
+cmd/dockcd/get.go       # CLI: get stacks / get stack <name>
+cmd/dockcd/suspend.go   # CLI: suspend stack
+cmd/dockcd/resume.go    # CLI: resume stack
+cmd/dockcd/logs.go      # CLI: stream logs
+cmd/dockcd/stats.go     # CLI: metrics summary
+cmd/dockcd/version.go   # CLI: version
+```

--- a/examples/gitops.yaml
+++ b/examples/gitops.yaml
@@ -1,13 +1,32 @@
 repo: git@github.com:user/infra.git
 base_path: /opt/stacks
+branch: main
+
+notifications:
+  - name: slack-alerts
+    type: slack
+    url: "${SLACK_WEBHOOK_URL}"
+    events:
+      - deploy_success
+      - deploy_failure
+      - rollback_success
+      - rollback_failure
+
 hosts:
   server01:
     stacks:
       - name: monitoring
         path: monitoring/
+        hooks:
+          pre_deploy:
+            command: "sops-decrypt.sh"
+            timeout: 15s
       - name: app
         path: app/
         depends_on: [monitoring]
         post_deploy_delay: 30s
         health_check_timeout: 90s
         auto_rollback: true
+        hooks:
+          pre_deploy:
+            command: "sops-decrypt.sh"

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,0 +1,185 @@
+// Package client provides an HTTP client for the dockcd server API.
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/mohitsharma44/dockcd/internal/server"
+)
+
+// Client communicates with a dockcd server over HTTP.
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// ReconcileResponse is returned by reconcile endpoints (202 Accepted).
+type ReconcileResponse struct {
+	ID     string `json:"id"`
+	Status string `json:"status"`
+	Stack  string `json:"stack,omitempty"`
+}
+
+// VersionResponse is returned by the /api/v1/version endpoint.
+type VersionResponse struct {
+	Server string `json:"server"`
+	Go     string `json:"go"`
+}
+
+// New returns a Client targeting baseURL (e.g. "http://localhost:9092").
+func New(baseURL string) *Client {
+	return &Client{
+		baseURL:    baseURL,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// GetStacks returns all stacks tracked by the server.
+func (c *Client) GetStacks() ([]server.StackState, error) {
+	resp, err := c.httpClient.Get(c.baseURL + "/api/v1/stacks")
+	if err != nil {
+		return nil, fmt.Errorf("connecting to server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("server returned %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		Stacks []server.StackState `json:"stacks"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	return payload.Stacks, nil
+}
+
+// GetStack returns a single stack by name.
+// Returns an error containing "not found" when the server responds 404.
+func (c *Client) GetStack(name string) (*server.StackState, error) {
+	resp, err := c.httpClient.Get(c.baseURL + "/api/v1/stacks/" + name)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("stack %q not found", name)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("server returned %d", resp.StatusCode)
+	}
+
+	var stack server.StackState
+	if err := json.NewDecoder(resp.Body).Decode(&stack); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	return &stack, nil
+}
+
+// Reconcile triggers an async reconciliation for the named stack.
+// The server responds 202 Accepted on success.
+func (c *Client) Reconcile(name string) (ReconcileResponse, error) {
+	resp, err := c.httpClient.Post(c.baseURL+"/api/v1/reconcile/"+name, "application/json", nil)
+	if err != nil {
+		return ReconcileResponse{}, fmt.Errorf("connecting to server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		return ReconcileResponse{}, fmt.Errorf("server returned %d", resp.StatusCode)
+	}
+
+	var r ReconcileResponse
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return ReconcileResponse{}, fmt.Errorf("decoding response: %w", err)
+	}
+	return r, nil
+}
+
+// ReconcileAll triggers an async reconciliation for all stacks.
+// The server responds 202 Accepted on success.
+func (c *Client) ReconcileAll() (ReconcileResponse, error) {
+	resp, err := c.httpClient.Post(c.baseURL+"/api/v1/reconcile", "application/json", nil)
+	if err != nil {
+		return ReconcileResponse{}, fmt.Errorf("connecting to server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		return ReconcileResponse{}, fmt.Errorf("server returned %d", resp.StatusCode)
+	}
+
+	var r ReconcileResponse
+	if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+		return ReconcileResponse{}, fmt.Errorf("decoding response: %w", err)
+	}
+	return r, nil
+}
+
+// Suspend suspends the named stack, returning the updated state.
+func (c *Client) Suspend(name string) (*server.StackState, error) {
+	resp, err := c.httpClient.Post(c.baseURL+"/api/v1/stacks/"+name+"/suspend", "application/json", nil)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("stack %q not found", name)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("server returned %d", resp.StatusCode)
+	}
+
+	var stack server.StackState
+	if err := json.NewDecoder(resp.Body).Decode(&stack); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	return &stack, nil
+}
+
+// Resume resumes the named stack, returning the updated state.
+func (c *Client) Resume(name string) (*server.StackState, error) {
+	resp, err := c.httpClient.Post(c.baseURL+"/api/v1/stacks/"+name+"/resume", "application/json", nil)
+	if err != nil {
+		return nil, fmt.Errorf("connecting to server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("stack %q not found", name)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("server returned %d", resp.StatusCode)
+	}
+
+	var stack server.StackState
+	if err := json.NewDecoder(resp.Body).Decode(&stack); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	return &stack, nil
+}
+
+// Version returns the server and Go runtime version reported by the server.
+func (c *Client) Version() (VersionResponse, error) {
+	resp, err := c.httpClient.Get(c.baseURL + "/api/v1/version")
+	if err != nil {
+		return VersionResponse{}, fmt.Errorf("connecting to server: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return VersionResponse{}, fmt.Errorf("server returned %d", resp.StatusCode)
+	}
+
+	var v VersionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+		return VersionResponse{}, fmt.Errorf("decoding response: %w", err)
+	}
+	return v, nil
+}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,0 +1,372 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mohitsharma44/dockcd/internal/server"
+)
+
+// sampleStack returns a consistent StackState for use in handler fixtures.
+func sampleStack(name string) server.StackState {
+	return server.StackState{
+		Name:       name,
+		Branch:     "main",
+		Status:     "Ready",
+		Health:     "Healthy",
+		LastDeploy: time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC),
+		Commit:     "abc1234",
+	}
+}
+
+func TestGetStacks(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/stacks" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"stacks": []server.StackState{sampleStack("web")},
+		})
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL)
+	stacks, err := c.GetStacks()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stacks) != 1 {
+		t.Fatalf("expected 1 stack, got %d", len(stacks))
+	}
+	if stacks[0].Name != "web" {
+		t.Errorf("expected name %q, got %q", "web", stacks[0].Name)
+	}
+	if stacks[0].Status != "Ready" {
+		t.Errorf("expected status %q, got %q", "Ready", stacks[0].Status)
+	}
+}
+
+func TestGetStacksEmpty(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"stacks": []server.StackState{}})
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL)
+	stacks, err := c.GetStacks()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stacks) != 0 {
+		t.Errorf("expected 0 stacks, got %d", len(stacks))
+	}
+}
+
+func TestGetStackNotFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "stack not found: missing"})
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL)
+	_, err := c.GetStack("missing")
+	if err == nil {
+		t.Fatal("expected error for 404, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "missing") {
+		t.Errorf("expected stack name in error, got: %v", err)
+	}
+}
+
+func TestGetStackFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/stacks/web" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		json.NewEncoder(w).Encode(sampleStack("web"))
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL)
+	stack, err := c.GetStack("web")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stack.Name != "web" {
+		t.Errorf("expected name %q, got %q", "web", stack.Name)
+	}
+	if stack.Health != "Healthy" {
+		t.Errorf("expected health %q, got %q", "Healthy", stack.Health)
+	}
+}
+
+func TestReconcile(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/reconcile/web" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusAccepted)
+		json.NewEncoder(w).Encode(map[string]string{
+			"id":     "rec-001",
+			"status": "queued",
+			"stack":  "web",
+		})
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL)
+	resp, err := c.Reconcile("web")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.ID != "rec-001" {
+		t.Errorf("expected ID %q, got %q", "rec-001", resp.ID)
+	}
+	if resp.Status != "queued" {
+		t.Errorf("expected status %q, got %q", "queued", resp.Status)
+	}
+	if resp.Stack != "web" {
+		t.Errorf("expected stack %q, got %q", "web", resp.Stack)
+	}
+}
+
+func TestReconcileAll(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/reconcile" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		w.WriteHeader(http.StatusAccepted)
+		json.NewEncoder(w).Encode(map[string]string{
+			"id":     "rec-all-001",
+			"status": "queued",
+		})
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL)
+	resp, err := c.ReconcileAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.ID != "rec-all-001" {
+		t.Errorf("expected ID %q, got %q", "rec-all-001", resp.ID)
+	}
+	if resp.Status != "queued" {
+		t.Errorf("expected status %q, got %q", "queued", resp.Status)
+	}
+}
+
+func TestSuspend(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/stacks/web/suspend" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		st := sampleStack("web")
+		st.Suspended = true
+		st.Status = "Suspended"
+		json.NewEncoder(w).Encode(st)
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL)
+	stack, err := c.Suspend("web")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stack.Suspended {
+		t.Error("expected Suspended=true")
+	}
+	if stack.Status != "Suspended" {
+		t.Errorf("expected status %q, got %q", "Suspended", stack.Status)
+	}
+}
+
+func TestSuspendNotFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "stack not found: ghost"})
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL)
+	_, err := c.Suspend("ghost")
+	if err == nil {
+		t.Fatal("expected error for 404, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got: %v", err)
+	}
+}
+
+func TestResume(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/stacks/web/resume" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		st := sampleStack("web")
+		st.Suspended = false
+		st.Status = "Ready"
+		json.NewEncoder(w).Encode(st)
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL)
+	stack, err := c.Resume("web")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stack.Suspended {
+		t.Error("expected Suspended=false after resume")
+	}
+	if stack.Status != "Ready" {
+		t.Errorf("expected status %q, got %q", "Ready", stack.Status)
+	}
+}
+
+func TestResumeNotFound(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		json.NewEncoder(w).Encode(map[string]string{"error": "stack not found: ghost"})
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL)
+	_, err := c.Resume("ghost")
+	if err == nil {
+		t.Fatal("expected error for 404, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got: %v", err)
+	}
+}
+
+func TestVersion(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/version" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		json.NewEncoder(w).Encode(map[string]string{
+			"server": "v0.1.0",
+			"go":     "go1.25.0",
+		})
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL)
+	v, err := c.Version()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.Server != "v0.1.0" {
+		t.Errorf("expected server version %q, got %q", "v0.1.0", v.Server)
+	}
+	if v.Go != "go1.25.0" {
+		t.Errorf("expected go version %q, got %q", "go1.25.0", v.Go)
+	}
+}
+
+func TestServerError(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		call       func(c *Client) error
+	}{
+		{
+			name:       "GetStacks 500",
+			statusCode: http.StatusInternalServerError,
+			call:       func(c *Client) error { _, err := c.GetStacks(); return err },
+		},
+		{
+			name:       "GetStack 500",
+			statusCode: http.StatusInternalServerError,
+			call:       func(c *Client) error { _, err := c.GetStack("web"); return err },
+		},
+		{
+			name:       "Reconcile 500",
+			statusCode: http.StatusInternalServerError,
+			call:       func(c *Client) error { _, err := c.Reconcile("web"); return err },
+		},
+		{
+			name:       "ReconcileAll 500",
+			statusCode: http.StatusInternalServerError,
+			call:       func(c *Client) error { _, err := c.ReconcileAll(); return err },
+		},
+		{
+			name:       "Suspend 500",
+			statusCode: http.StatusInternalServerError,
+			call:       func(c *Client) error { _, err := c.Suspend("web"); return err },
+		},
+		{
+			name:       "Resume 500",
+			statusCode: http.StatusInternalServerError,
+			call:       func(c *Client) error { _, err := c.Resume("web"); return err },
+		},
+		{
+			name:       "Version 500",
+			statusCode: http.StatusInternalServerError,
+			call:       func(c *Client) error { _, err := c.Version(); return err },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.statusCode)
+			}))
+			defer ts.Close()
+
+			c := New(ts.URL)
+			err := tt.call(c)
+			if err == nil {
+				t.Fatal("expected error for 5xx response, got nil")
+			}
+			if !strings.Contains(err.Error(), "500") {
+				t.Errorf("expected status code in error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestConnectionError(t *testing.T) {
+	// Point at a port that will refuse connections.
+	c := New("http://127.0.0.1:1")
+
+	t.Run("GetStacks connection refused", func(t *testing.T) {
+		_, err := c.GetStacks()
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "connecting to server") {
+			t.Errorf("expected 'connecting to server' in error, got: %v", err)
+		}
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,6 +74,15 @@ type Stack struct {
 	Hooks              *Hooks         `yaml:"hooks"`
 }
 
+// EffectiveBranch returns the branch this stack tracks.
+// Falls back to defaultBranch if not explicitly set.
+func (s *Stack) EffectiveBranch(defaultBranch string) string {
+	if s.Branch != "" {
+		return s.Branch
+	}
+	return defaultBranch
+}
+
 // RollbackEnabled returns whether auto-rollback is enabled for this stack.
 // Defaults to true if not explicitly set.
 func (s *Stack) RollbackEnabled() bool {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,23 +8,70 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type Config struct {
-	Repo     string                `yaml:"repo"`
-	BasePath string                `yaml:"base_path"`
-	Hosts    map[string]HostConfig `yaml:"hosts"`
+// validNotificationTypes holds the accepted notification backend types.
+var validNotificationTypes = map[string]bool{
+	"slack":   true,
+	"webhook": true,
 }
 
+// validEventTypes holds the accepted event names for notifications.
+var validEventTypes = map[string]bool{
+	"deploy_success":     true,
+	"deploy_failure":     true,
+	"rollback_success":   true,
+	"rollback_failure":   true,
+	"reconcile_start":    true,
+	"reconcile_complete": true,
+	"force_deploy":       true,
+	"stack_suspended":    true,
+	"stack_resumed":      true,
+	"hook_failure":       true,
+}
+
+// HookConfig describes a single lifecycle hook.
+type HookConfig struct {
+	Command string        `yaml:"command"`
+	Timeout time.Duration `yaml:"timeout"`
+}
+
+// Hooks groups the pre- and post-deploy hooks for a stack.
+type Hooks struct {
+	PreDeploy  *HookConfig `yaml:"pre_deploy"`
+	PostDeploy *HookConfig `yaml:"post_deploy"`
+}
+
+// NotificationConfig describes a single notification target.
+type NotificationConfig struct {
+	Name   string   `yaml:"name"`
+	Type   string   `yaml:"type"`
+	URL    string   `yaml:"url"`
+	Events []string `yaml:"events"`
+}
+
+// Config is the top-level configuration for dockcd.
+type Config struct {
+	Repo          string                `yaml:"repo"`
+	BasePath      string                `yaml:"base_path"`
+	Branch        string                `yaml:"branch"`
+	Notifications []NotificationConfig  `yaml:"notifications"`
+	Hosts         map[string]HostConfig `yaml:"hosts"`
+}
+
+// HostConfig holds the list of stacks for a single host.
 type HostConfig struct {
 	Stacks []Stack `yaml:"stacks"`
 }
 
+// Stack describes a single Docker Compose stack managed by dockcd.
 type Stack struct {
 	Name               string         `yaml:"name"`
 	Path               string         `yaml:"path"`
+	Branch             string         `yaml:"branch"`
 	DependsOn          []string       `yaml:"depends_on"`
 	PostDeployDelay    time.Duration  `yaml:"post_deploy_delay"`
 	HealthCheckTimeout *time.Duration `yaml:"health_check_timeout"`
 	AutoRollback       *bool          `yaml:"auto_rollback"`
+	Hooks              *Hooks         `yaml:"hooks"`
 }
 
 // RollbackEnabled returns whether auto-rollback is enabled for this stack.
@@ -47,20 +94,33 @@ func (s *Stack) HealthTimeout() time.Duration {
 
 func (s *Stack) UnmarshalYAML(value *yaml.Node) error {
 	var raw struct {
-		Name               string   `yaml:"name"`
-		Path               string   `yaml:"path"`
+		Name               string `yaml:"name"`
+		Path               string `yaml:"path"`
+		Branch             string `yaml:"branch"`
 		DependsOn          []string `yaml:"depends_on"`
 		PostDeployDelay    string   `yaml:"post_deploy_delay"`
 		HealthCheckTimeout string   `yaml:"health_check_timeout"`
 		AutoRollback       *bool    `yaml:"auto_rollback"`
+		Hooks              *struct {
+			PreDeploy  *struct {
+				Command string `yaml:"command"`
+				Timeout string `yaml:"timeout"`
+			} `yaml:"pre_deploy"`
+			PostDeploy *struct {
+				Command string `yaml:"command"`
+				Timeout string `yaml:"timeout"`
+			} `yaml:"post_deploy"`
+		} `yaml:"hooks"`
 	}
 	if err := value.Decode(&raw); err != nil {
 		return err
 	}
 	s.Name = raw.Name
 	s.Path = raw.Path
+	s.Branch = raw.Branch
 	s.DependsOn = raw.DependsOn
 	s.AutoRollback = raw.AutoRollback
+
 	if raw.PostDeployDelay != "" {
 		d, err := time.ParseDuration(raw.PostDeployDelay)
 		if err != nil {
@@ -76,19 +136,50 @@ func (s *Stack) UnmarshalYAML(value *yaml.Node) error {
 		timeout := d
 		s.HealthCheckTimeout = &timeout
 	}
+
+	if raw.Hooks != nil {
+		s.Hooks = &Hooks{}
+		if raw.Hooks.PreDeploy != nil {
+			hc := &HookConfig{Command: raw.Hooks.PreDeploy.Command}
+			if raw.Hooks.PreDeploy.Timeout != "" {
+				d, err := time.ParseDuration(raw.Hooks.PreDeploy.Timeout)
+				if err != nil {
+					return fmt.Errorf("invalid pre_deploy hook timeout %q for stack %q: %w", raw.Hooks.PreDeploy.Timeout, raw.Name, err)
+				}
+				hc.Timeout = d
+			}
+			s.Hooks.PreDeploy = hc
+		}
+		if raw.Hooks.PostDeploy != nil {
+			hc := &HookConfig{Command: raw.Hooks.PostDeploy.Command}
+			if raw.Hooks.PostDeploy.Timeout != "" {
+				d, err := time.ParseDuration(raw.Hooks.PostDeploy.Timeout)
+				if err != nil {
+					return fmt.Errorf("invalid post_deploy hook timeout %q for stack %q: %w", raw.Hooks.PostDeploy.Timeout, raw.Name, err)
+				}
+				hc.Timeout = d
+			}
+			s.Hooks.PostDeploy = hc
+		}
+	}
+
 	return nil
 }
 
 var ErrCycleDetected = fmt.Errorf("dependency cycle detected")
 
+// Load reads, env-expands, parses, and validates the config at path.
 func Load(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading config file: %w", err)
 	}
 
+	// Expand ${VAR} and $VAR references before YAML parsing.
+	expanded := os.ExpandEnv(string(data))
+
 	var cfg Config
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	if err := yaml.Unmarshal([]byte(expanded), &cfg); err != nil {
 		return nil, fmt.Errorf("parsing config file: %w", err)
 	}
 
@@ -120,6 +211,14 @@ func validate(cfg *Config) error {
 			if st.Path == "" {
 				return fmt.Errorf("host %q: stack %q path is required", hostName, st.Name)
 			}
+			if st.Hooks != nil {
+				if st.Hooks.PreDeploy != nil && st.Hooks.PreDeploy.Command == "" {
+					return fmt.Errorf("host %q: stack %q: pre_deploy hook command must not be empty", hostName, st.Name)
+				}
+				if st.Hooks.PostDeploy != nil && st.Hooks.PostDeploy.Command == "" {
+					return fmt.Errorf("host %q: stack %q: post_deploy hook command must not be empty", hostName, st.Name)
+				}
+			}
 			stackNames[st.Name] = true
 		}
 		for _, st := range host.Stacks {
@@ -134,6 +233,21 @@ func validate(cfg *Config) error {
 			return fmt.Errorf("host %q: %w", hostName, err)
 		}
 	}
+
+	for i, n := range cfg.Notifications {
+		if !validNotificationTypes[n.Type] {
+			return fmt.Errorf("notification %d (%q): invalid notification type %q", i, n.Name, n.Type)
+		}
+		if n.URL == "" {
+			return fmt.Errorf("notification %d (%q): notification URL must not be empty", i, n.Name)
+		}
+		for _, ev := range n.Events {
+			if !validEventTypes[ev] {
+				return fmt.Errorf("notification %d (%q): invalid notification event %q", i, n.Name, ev)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -695,3 +695,15 @@ hosts:
 		t.Fatalf("expected URL empty error, got %q", err.Error())
 	}
 }
+
+func TestEffectiveBranch(t *testing.T) {
+	s := Stack{Name: "web"}
+	if got := s.EffectiveBranch("main"); got != "main" {
+		t.Errorf("expected 'main', got %q", got)
+	}
+
+	s.Branch = "canary"
+	if got := s.EffectiveBranch("main"); got != "canary" {
+		t.Errorf("expected 'canary', got %q", got)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -278,3 +278,420 @@ hosts:
 		}
 	}
 }
+
+func TestLoadHooksConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "valid pre and post deploy hooks",
+			yaml: `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+        hooks:
+          pre_deploy:
+            command: "pre.sh"
+            timeout: 10s
+          post_deploy:
+            command: "post.sh"
+            timeout: 20s
+`,
+			wantErr: "",
+		},
+		{
+			name: "pre_deploy only",
+			yaml: `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+        hooks:
+          pre_deploy:
+            command: "pre.sh"
+`,
+			wantErr: "",
+		},
+		{
+			name: "post_deploy only",
+			yaml: `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+        hooks:
+          post_deploy:
+            command: "post.sh"
+`,
+			wantErr: "",
+		},
+		{
+			name: "pre_deploy empty command",
+			yaml: `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+        hooks:
+          pre_deploy:
+            command: ""
+`,
+			wantErr: "pre_deploy hook command must not be empty",
+		},
+		{
+			name: "post_deploy empty command",
+			yaml: `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+        hooks:
+          post_deploy:
+            command: ""
+`,
+			wantErr: "post_deploy hook command must not be empty",
+		},
+		{
+			name: "no hooks backward compat",
+			yaml: `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+`,
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeTemp(t, tt.yaml)
+			cfg, err := Load(path)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			_ = cfg
+		})
+	}
+}
+
+func TestLoadHookTimeout(t *testing.T) {
+	content := `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+        hooks:
+          pre_deploy:
+            command: "pre.sh"
+            timeout: 10s
+          post_deploy:
+            command: "post.sh"
+            timeout: 2m
+`
+	path := writeTemp(t, content)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	stacks := cfg.Hosts["server01"].Stacks
+	if len(stacks) != 1 {
+		t.Fatalf("expected 1 stack, got %d", len(stacks))
+	}
+	st := stacks[0]
+	if st.Hooks == nil {
+		t.Fatal("expected hooks to be non-nil")
+	}
+	if st.Hooks.PreDeploy == nil {
+		t.Fatal("expected pre_deploy hook to be non-nil")
+	}
+	if st.Hooks.PreDeploy.Timeout != 10*time.Second {
+		t.Errorf("pre_deploy timeout: expected 10s, got %v", st.Hooks.PreDeploy.Timeout)
+	}
+	if st.Hooks.PostDeploy == nil {
+		t.Fatal("expected post_deploy hook to be non-nil")
+	}
+	if st.Hooks.PostDeploy.Timeout != 2*time.Minute {
+		t.Errorf("post_deploy timeout: expected 2m, got %v", st.Hooks.PostDeploy.Timeout)
+	}
+}
+
+func TestLoadBranchConfig(t *testing.T) {
+	content := `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+branch: main
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+        branch: feature/dev
+      - name: db
+        path: db/
+`
+	path := writeTemp(t, content)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Branch != "main" {
+		t.Errorf("top-level branch: expected %q, got %q", "main", cfg.Branch)
+	}
+
+	stacks := cfg.Hosts["server01"].Stacks
+	for _, st := range stacks {
+		switch st.Name {
+		case "app":
+			if st.Branch != "feature/dev" {
+				t.Errorf("app stack branch: expected %q, got %q", "feature/dev", st.Branch)
+			}
+		case "db":
+			if st.Branch != "" {
+				t.Errorf("db stack branch: expected empty, got %q", st.Branch)
+			}
+		}
+	}
+}
+
+func TestLoadNotifications(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr string
+	}{
+		{
+			name: "valid slack notification",
+			yaml: `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+notifications:
+  - name: slack-alerts
+    type: slack
+    url: "https://hooks.slack.com/services/xxx"
+    events:
+      - deploy_success
+      - deploy_failure
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+`,
+			wantErr: "",
+		},
+		{
+			name: "valid webhook notification",
+			yaml: `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+notifications:
+  - name: my-webhook
+    type: webhook
+    url: "https://example.com/hook"
+    events:
+      - rollback_success
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+`,
+			wantErr: "",
+		},
+		{
+			name: "invalid notification type",
+			yaml: `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+notifications:
+  - name: discord-alerts
+    type: discord
+    url: "https://discord.com/api/webhooks/xxx"
+    events:
+      - deploy_success
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+`,
+			wantErr: "invalid notification type",
+		},
+		{
+			name: "empty notification URL",
+			yaml: `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+notifications:
+  - name: slack-alerts
+    type: slack
+    url: ""
+    events:
+      - deploy_success
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+`,
+			wantErr: "notification URL must not be empty",
+		},
+		{
+			name: "invalid event name",
+			yaml: `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+notifications:
+  - name: slack-alerts
+    type: slack
+    url: "https://hooks.slack.com/services/xxx"
+    events:
+      - not_a_real_event
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+`,
+			wantErr: "invalid notification event",
+		},
+		{
+			name: "no notifications section",
+			yaml: `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+`,
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeTemp(t, tt.yaml)
+			cfg, err := Load(path)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tt.wantErr, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			_ = cfg
+		})
+	}
+}
+
+func TestLoadEnvVarSubstitution(t *testing.T) {
+	t.Setenv("TEST_REPO_URL", "git@github.com:test/repo.git")
+	t.Setenv("TEST_SLACK_URL", "https://hooks.slack.com/services/test")
+
+	content := `
+repo: ${TEST_REPO_URL}
+base_path: /opt/stacks
+notifications:
+  - name: slack-alerts
+    type: slack
+    url: "${TEST_SLACK_URL}"
+    events:
+      - deploy_success
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+`
+	path := writeTemp(t, content)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Repo != "git@github.com:test/repo.git" {
+		t.Errorf("repo: expected expanded value, got %q", cfg.Repo)
+	}
+	if len(cfg.Notifications) != 1 {
+		t.Fatalf("expected 1 notification, got %d", len(cfg.Notifications))
+	}
+	if cfg.Notifications[0].URL != "https://hooks.slack.com/services/test" {
+		t.Errorf("notification URL: expected expanded value, got %q", cfg.Notifications[0].URL)
+	}
+}
+
+func TestLoadEnvVarSubstitutionUnsetVar(t *testing.T) {
+	// Ensure the var is unset
+	os.Unsetenv("UNSET_WEBHOOK_URL")
+
+	content := `
+repo: git@github.com:user/infra.git
+base_path: /opt/stacks
+notifications:
+  - name: slack-alerts
+    type: slack
+    url: "${UNSET_WEBHOOK_URL}"
+    events:
+      - deploy_success
+hosts:
+  server01:
+    stacks:
+      - name: app
+        path: app/
+`
+	path := writeTemp(t, content)
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error for empty URL after env expansion, got nil")
+	}
+	if !strings.Contains(err.Error(), "notification URL must not be empty") {
+		t.Fatalf("expected URL empty error, got %q", err.Error())
+	}
+}

--- a/internal/deploy/compose.go
+++ b/internal/deploy/compose.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+
+	"github.com/mohitsharma44/dockcd/internal/hooks"
 )
 
 // CommandRunner is a function that runs a shell command in a directory.
@@ -12,7 +14,8 @@ import (
 type CommandRunner func(ctx context.Context, dir string, name string, args ...string) error
 
 // Deploy runs docker compose pull + up for a single stack.
-func Deploy(ctx context.Context, stack Stack, repoDir string, run CommandRunner) error {
+// env is passed to any configured pre/post-deploy hooks.
+func Deploy(ctx context.Context, stack Stack, repoDir string, run CommandRunner, env hooks.Env) error {
 	if filepath.IsAbs(stack.Path) {
 		return fmt.Errorf("stack %q: path must be relative, got %q", stack.Name, stack.Path)
 	}
@@ -32,12 +35,26 @@ func Deploy(ctx context.Context, stack Stack, repoDir string, run CommandRunner)
 		return fmt.Errorf("stack %q: path %q escapes repo directory", stack.Name, stack.Path)
 	}
 
+	// Run pre-deploy hook before compose commands. Failure skips compose.
+	if stack.PreDeployHook != nil {
+		if _, err := hooks.Run(ctx, *stack.PreDeployHook, dir, env); err != nil {
+			return fmt.Errorf("stack %q: pre-deploy hook: %w", stack.Name, err)
+		}
+	}
+
 	if err := run(ctx, dir, "docker", "compose", "-p", stack.Name, "pull"); err != nil {
 		return fmt.Errorf("stack %q: compose pull: %w", stack.Name, err)
 	}
 
 	if err := run(ctx, dir, "docker", "compose", "-p", stack.Name, "up", "-d", "--remove-orphans"); err != nil {
 		return fmt.Errorf("stack %q: compose up: %w", stack.Name, err)
+	}
+
+	// Run post-deploy hook after compose up. Compose already ran, return error if hook fails.
+	if stack.PostDeployHook != nil {
+		if _, err := hooks.Run(ctx, *stack.PostDeployHook, dir, env); err != nil {
+			return fmt.Errorf("stack %q: post-deploy hook: %w", stack.Name, err)
+		}
 	}
 
 	return nil

--- a/internal/deploy/compose_test.go
+++ b/internal/deploy/compose_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/mohitsharma44/dockcd/internal/hooks"
 )
 
 func TestDeployRunsComposeUp(t *testing.T) {
@@ -17,7 +20,7 @@ func TestDeployRunsComposeUp(t *testing.T) {
 	}
 
 	stack := Stack{Name: "web", Path: "web/"}
-	err := Deploy(context.Background(), stack, "/opt/repo", fakeRunner)
+	err := Deploy(context.Background(), stack, "/opt/repo", fakeRunner, hooks.Env{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -51,7 +54,7 @@ func TestDeployRejectsAbsolutePath(t *testing.T) {
 	}
 
 	stack := Stack{Name: "evil", Path: "/etc/something"}
-	err := Deploy(context.Background(), stack, "/opt/repo", fakeRunner)
+	err := Deploy(context.Background(), stack, "/opt/repo", fakeRunner, hooks.Env{})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -66,11 +69,131 @@ func TestDeployRejectsPathTraversal(t *testing.T) {
 	}
 
 	stack := Stack{Name: "evil", Path: "../../etc/something"}
-	err := Deploy(context.Background(), stack, "/opt/repo", fakeRunner)
+	err := Deploy(context.Background(), stack, "/opt/repo", fakeRunner, hooks.Env{})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
 	if !strings.Contains(err.Error(), "escapes repo") {
 		t.Fatalf("expected 'escapes repo' error, got %v", err)
+	}
+}
+
+// TestDeployNoHooksBackwardCompat verifies that Deploy without hooks still
+// runs exactly 2 compose commands (pull + up).
+func TestDeployNoHooksBackwardCompat(t *testing.T) {
+	var composeCalls int
+	fakeRunner := func(ctx context.Context, dir string, name string, args ...string) error {
+		composeCalls++
+		return nil
+	}
+
+	dir := t.TempDir()
+	stack := Stack{Name: "web", Path: "."}
+	err := Deploy(context.Background(), stack, dir, fakeRunner, hooks.Env{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if composeCalls != 2 {
+		t.Errorf("expected 2 compose calls, got %d", composeCalls)
+	}
+}
+
+// TestDeployRunsPreDeployHook verifies that a pre-deploy hook runs and compose
+// still executes afterward (2 compose calls total).
+func TestDeployRunsPreDeployHook(t *testing.T) {
+	var composeCalls int
+	fakeRunner := func(ctx context.Context, dir string, name string, args ...string) error {
+		composeCalls++
+		return nil
+	}
+
+	dir := t.TempDir()
+	stack := Stack{
+		Name: "web",
+		Path: ".",
+		PreDeployHook: &hooks.Config{
+			Command: "true", // exits 0
+			Timeout: 5 * time.Second,
+		},
+	}
+	err := Deploy(context.Background(), stack, dir, fakeRunner, hooks.Env{
+		StackName: "web",
+		Commit:    "abc123",
+		RepoDir:   dir,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if composeCalls != 2 {
+		t.Errorf("expected 2 compose calls after pre-deploy hook, got %d", composeCalls)
+	}
+}
+
+// TestDeployPreHookFailureSkipsCompose verifies that a failing pre-deploy hook
+// causes Deploy to return an error and no compose commands are run.
+func TestDeployPreHookFailureSkipsCompose(t *testing.T) {
+	var composeCalls int
+	fakeRunner := func(ctx context.Context, dir string, name string, args ...string) error {
+		composeCalls++
+		return nil
+	}
+
+	dir := t.TempDir()
+	stack := Stack{
+		Name: "web",
+		Path: ".",
+		PreDeployHook: &hooks.Config{
+			Command: "exit 1",
+			Timeout: 5 * time.Second,
+		},
+	}
+	err := Deploy(context.Background(), stack, dir, fakeRunner, hooks.Env{
+		StackName: "web",
+		Commit:    "abc123",
+		RepoDir:   dir,
+	})
+	if err == nil {
+		t.Fatal("expected error from failing pre-deploy hook, got nil")
+	}
+	if !strings.Contains(err.Error(), "pre-deploy hook") {
+		t.Errorf("expected error to mention 'pre-deploy hook', got: %v", err)
+	}
+	if composeCalls != 0 {
+		t.Errorf("expected 0 compose calls when pre-deploy hook fails, got %d", composeCalls)
+	}
+}
+
+// TestDeployPostHookFailureStillDeployed verifies that a failing post-deploy hook
+// returns an error but compose commands were still executed (2 calls).
+func TestDeployPostHookFailureStillDeployed(t *testing.T) {
+	var composeCalls int
+	fakeRunner := func(ctx context.Context, dir string, name string, args ...string) error {
+		composeCalls++
+		return nil
+	}
+
+	dir := t.TempDir()
+	stack := Stack{
+		Name: "web",
+		Path: ".",
+		PostDeployHook: &hooks.Config{
+			Command: "exit 1",
+			Timeout: 5 * time.Second,
+		},
+	}
+	err := Deploy(context.Background(), stack, dir, fakeRunner, hooks.Env{
+		StackName: "web",
+		Commit:    "abc123",
+		RepoDir:   dir,
+	})
+	if err == nil {
+		t.Fatal("expected error from failing post-deploy hook, got nil")
+	}
+	if !strings.Contains(err.Error(), "post-deploy hook") {
+		t.Errorf("expected error to mention 'post-deploy hook', got: %v", err)
+	}
+	// Compose should have run (pull + up = 2 calls) before the post hook failed.
+	if composeCalls != 2 {
+		t.Errorf("expected 2 compose calls (deploy ran before post hook), got %d", composeCalls)
 	}
 }

--- a/internal/deploy/graph.go
+++ b/internal/deploy/graph.go
@@ -3,6 +3,8 @@ package deploy
 import (
 	"fmt"
 	"time"
+
+	"github.com/mohitsharma44/dockcd/internal/hooks"
 )
 
 // ErrCycleDetected is returned when stacks have circular dependencies.
@@ -16,6 +18,8 @@ type Stack struct {
 	DependsOn          []string
 	HealthCheckTimeout time.Duration
 	AutoRollback       bool
+	PreDeployHook      *hooks.Config
+	PostDeployHook     *hooks.Config
 }
 
 // BuildGraph takes a list of stacks and returns parallel deployment groups

--- a/internal/deploy/runner.go
+++ b/internal/deploy/runner.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/mohitsharma44/dockcd/internal/hooks"
 	"golang.org/x/sync/errgroup"
 )
 
 // RunGroups deploys stacks group by group. Groups run sequentially,
 // but stacks within a group run in parallel. Stops on first error.
-func RunGroups(ctx context.Context, groups [][]Stack, repoDir string, run CommandRunner) error {
+func RunGroups(ctx context.Context, groups [][]Stack, repoDir string, run CommandRunner, env hooks.Env) error {
 	for i, group := range groups {
 		g, ctx := errgroup.WithContext(ctx)
 
@@ -17,7 +18,7 @@ func RunGroups(ctx context.Context, groups [][]Stack, repoDir string, run Comman
 			// capture loop variable since it's a goroutine
 			stack := stack
 			g.Go(func() error {
-				return Deploy(ctx, stack, repoDir, run)
+				return Deploy(ctx, stack, repoDir, run, env)
 			})
 		}
 		if err := g.Wait(); err != nil {

--- a/internal/deploy/runner_test.go
+++ b/internal/deploy/runner_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/mohitsharma44/dockcd/internal/hooks"
 )
 
 func containsArg(args []string, target string) bool {
@@ -38,7 +40,7 @@ func TestRunGroupsSequentialOrder(t *testing.T) {
 		{{Name: "c", Path: "c/"}},
 	}
 
-	err := RunGroups(context.Background(), groups, "/opt/repo", fakeRunner)
+	err := RunGroups(context.Background(), groups, "/opt/repo", fakeRunner, hooks.Env{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -79,7 +81,7 @@ func TestRunGroupsParallelWithinGroup(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- RunGroups(context.Background(), groups, "/opt/repo", fakeRunner)
+		done <- RunGroups(context.Background(), groups, "/opt/repo", fakeRunner, hooks.Env{})
 	}()
 
 	// Both should signal "started" since they're parallel.
@@ -117,7 +119,7 @@ func TestRunGroupsStopsOnError(t *testing.T) {
 		{{Name: "b", Path: "b/"}}, // should never run
 	}
 
-	err := RunGroups(context.Background(), groups, "/opt/repo", fakeRunner)
+	err := RunGroups(context.Background(), groups, "/opt/repo", fakeRunner, hooks.Env{})
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/internal/git/poller.go
+++ b/internal/git/poller.go
@@ -13,26 +13,31 @@ import (
 // State is the JSON-serialized state file format.
 type State struct {
 	LastHash              string            `json:"last_hash"`
+	Branches              map[string]string `json:"branches,omitempty"`
 	LastSuccessfulCommits map[string]string `json:"last_successful_commits"`
 	SuspendedStacks       []string          `json:"suspended_stacks,omitempty"`
 }
 
 type Poller struct {
-	repoURL        string
-	localDir       string
-	lastHash       string
-	stateFile      string
-	branch         string
-	state          State
-	needsReconcile map[string]bool
-	mu             sync.Mutex // protects state and file writes
+	repoURL         string
+	localDir        string
+	lastHash        string
+	stateFile       string
+	branch          string
+	state           State
+	needsReconcile  map[string]bool
+	trackedBranches []string // branches to poll (configured from stack configs)
+	mu              sync.Mutex // protects state and file writes
 }
 
 func NewPoller(repoURL, localDir string) *Poller {
 	return &Poller{
-		repoURL:        repoURL,
-		localDir:       localDir,
-		state:          State{LastSuccessfulCommits: make(map[string]string)},
+		repoURL:  repoURL,
+		localDir: localDir,
+		state: State{
+			LastSuccessfulCommits: make(map[string]string),
+			Branches:              make(map[string]string),
+		},
 		needsReconcile: make(map[string]bool),
 	}
 }
@@ -111,6 +116,13 @@ func (p *Poller) LoadState() error {
 	}
 	if state.LastSuccessfulCommits == nil {
 		state.LastSuccessfulCommits = make(map[string]string)
+	}
+	if state.Branches == nil {
+		state.Branches = make(map[string]string)
+		// Migrate: if an old state had a hash but no Branches map, seed it.
+		if state.LastHash != "" && p.branch != "" {
+			state.Branches[p.branch] = state.LastHash
+		}
 	}
 	p.state = state
 	p.lastHash = state.LastHash
@@ -196,6 +208,29 @@ func (p *Poller) ClearNeedsReconcile(name string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	delete(p.needsReconcile, name)
+}
+
+// SetTrackedBranches configures the set of branches the poller should track.
+func (p *Poller) SetTrackedBranches(branches []string) {
+	p.trackedBranches = branches
+}
+
+// LastHashForBranch returns the last known HEAD hash for the given branch,
+// or empty string if the branch has not been seen yet.
+func (p *Poller) LastHashForBranch(branch string) string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.state.Branches == nil {
+		return ""
+	}
+	return p.state.Branches[branch]
+}
+
+// ExtractBranchFiles extracts stack files from a non-default branch
+// using git archive, writing to destDir. It delegates to ExtractAtCommit
+// using origin/<branch> as the ref so the working tree is not modified.
+func (p *Poller) ExtractBranchFiles(branch, stackPath, destDir string) error {
+	return p.ExtractAtCommit("origin/"+branch, stackPath, destDir)
 }
 
 // ExtractAtCommit writes the files under pathPrefix at the given commit to destDir.

--- a/internal/git/poller.go
+++ b/internal/git/poller.go
@@ -14,23 +14,26 @@ import (
 type State struct {
 	LastHash              string            `json:"last_hash"`
 	LastSuccessfulCommits map[string]string `json:"last_successful_commits"`
+	SuspendedStacks       []string          `json:"suspended_stacks,omitempty"`
 }
 
 type Poller struct {
-	repoURL   string
-	localDir  string
-	lastHash  string
-	stateFile string
-	branch    string
-	state     State
-	mu        sync.Mutex // protects state and file writes
+	repoURL        string
+	localDir       string
+	lastHash       string
+	stateFile      string
+	branch         string
+	state          State
+	needsReconcile map[string]bool
+	mu             sync.Mutex // protects state and file writes
 }
 
 func NewPoller(repoURL, localDir string) *Poller {
 	return &Poller{
-		repoURL:  repoURL,
-		localDir: localDir,
-		state:    State{LastSuccessfulCommits: make(map[string]string)},
+		repoURL:        repoURL,
+		localDir:       localDir,
+		state:          State{LastSuccessfulCommits: make(map[string]string)},
+		needsReconcile: make(map[string]bool),
 	}
 }
 
@@ -128,6 +131,71 @@ func (p *Poller) SetLastSuccessfulCommit(stack, hash string) error {
 	defer p.mu.Unlock()
 	p.state.LastSuccessfulCommits[stack] = hash
 	return p.saveStateLocked()
+}
+
+// SuspendStack marks a stack as suspended and persists state.
+// Idempotent — suspending an already-suspended stack is a no-op.
+func (p *Poller) SuspendStack(name string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, s := range p.state.SuspendedStacks {
+		if s == name {
+			return nil
+		}
+	}
+	p.state.SuspendedStacks = append(p.state.SuspendedStacks, name)
+	return p.saveStateLocked()
+}
+
+// ResumeStack removes a stack from the suspended set, marks it as needing
+// reconcile, and persists state.
+// Idempotent — resuming a non-suspended stack is a no-op.
+func (p *Poller) ResumeStack(name string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	filtered := p.state.SuspendedStacks[:0]
+	found := false
+	for _, s := range p.state.SuspendedStacks {
+		if s == name {
+			found = true
+			continue
+		}
+		filtered = append(filtered, s)
+	}
+	if !found {
+		return nil
+	}
+	p.state.SuspendedStacks = filtered
+	p.needsReconcile[name] = true
+	return p.saveStateLocked()
+}
+
+// IsSuspended returns true if the stack is currently suspended.
+func (p *Poller) IsSuspended(name string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for _, s := range p.state.SuspendedStacks {
+		if s == name {
+			return true
+		}
+	}
+	return false
+}
+
+// NeedsReconcile returns true if the stack was recently resumed and needs
+// a reconcile pass.
+func (p *Poller) NeedsReconcile(name string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.needsReconcile[name]
+}
+
+// ClearNeedsReconcile clears the needs-reconcile flag after the stack has
+// been reconciled.
+func (p *Poller) ClearNeedsReconcile(name string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.needsReconcile, name)
 }
 
 // ExtractAtCommit writes the files under pathPrefix at the given commit to destDir.

--- a/internal/git/poller_test.go
+++ b/internal/git/poller_test.go
@@ -251,6 +251,55 @@ func TestResumeNotSuspended(t *testing.T) {
 	}
 }
 
+func TestLastHashForBranch(t *testing.T) {
+	dir := t.TempDir()
+	p := NewPoller("", dir)
+	p.state.Branches = map[string]string{"main": "aaa", "canary": "bbb"}
+
+	if got := p.LastHashForBranch("main"); got != "aaa" {
+		t.Errorf("expected 'aaa', got %q", got)
+	}
+	if got := p.LastHashForBranch("canary"); got != "bbb" {
+		t.Errorf("expected 'bbb', got %q", got)
+	}
+	if got := p.LastHashForBranch("unknown"); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestSetTrackedBranches(t *testing.T) {
+	p := NewPoller("", t.TempDir())
+	p.SetTrackedBranches([]string{"main", "canary"})
+	if len(p.trackedBranches) != 2 {
+		t.Fatalf("expected 2 tracked branches, got %d", len(p.trackedBranches))
+	}
+}
+
+func TestStateMigrationAddsBranches(t *testing.T) {
+	dir := t.TempDir()
+	stateFile := filepath.Join(dir, ".dockcd_state")
+
+	// Old-format state without branches field.
+	data := `{"last_hash":"abc123","last_successful_commits":{"web":"abc123"}}`
+	if err := os.WriteFile(stateFile, []byte(data), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	p := NewPoller("", dir)
+	p.SetStateFile(stateFile)
+	p.branch = "main"
+	if err := p.LoadState(); err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+
+	if p.state.Branches == nil {
+		t.Fatal("expected Branches to be initialized")
+	}
+	if p.state.Branches["main"] != "abc123" {
+		t.Errorf("expected Branches[main]='abc123', got %q", p.state.Branches["main"])
+	}
+}
+
 func TestBackwardCompatNoSuspendedField(t *testing.T) {
 	stateFile := filepath.Join(t.TempDir(), "state.json")
 

--- a/internal/git/poller_test.go
+++ b/internal/git/poller_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -161,5 +162,127 @@ func TestStateFilePersistence(t *testing.T) {
 
 	if p2.LastHash() != hash1 {
 		t.Fatalf("expected loaded lastHash=%q, got %q", hash1, p2.LastHash())
+	}
+}
+
+func TestSuspendResumePersistence(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "state.json")
+
+	p1 := NewPoller("", "")
+	p1.SetStateFile(stateFile)
+
+	// Suspend "app".
+	if err := p1.SuspendStack("app"); err != nil {
+		t.Fatalf("SuspendStack error: %v", err)
+	}
+	if !p1.IsSuspended("app") {
+		t.Fatal("expected app to be suspended")
+	}
+
+	// Reload state in a new poller — suspension must survive restart.
+	p2 := NewPoller("", "")
+	p2.SetStateFile(stateFile)
+	if err := p2.LoadState(); err != nil {
+		t.Fatalf("LoadState error: %v", err)
+	}
+	if !p2.IsSuspended("app") {
+		t.Fatal("expected app to still be suspended after reload")
+	}
+	if p2.NeedsReconcile("app") {
+		t.Fatal("freshly loaded poller should not have needsReconcile set")
+	}
+
+	// Resume "app" and verify state.
+	if err := p2.ResumeStack("app"); err != nil {
+		t.Fatalf("ResumeStack error: %v", err)
+	}
+	if p2.IsSuspended("app") {
+		t.Fatal("app should not be suspended after resume")
+	}
+	if !p2.NeedsReconcile("app") {
+		t.Fatal("expected needsReconcile to be set after resume")
+	}
+
+	// Reload again — app must no longer appear in SuspendedStacks.
+	p3 := NewPoller("", "")
+	p3.SetStateFile(stateFile)
+	if err := p3.LoadState(); err != nil {
+		t.Fatalf("LoadState error: %v", err)
+	}
+	if p3.IsSuspended("app") {
+		t.Fatal("app should not be suspended in p3 after resume+persist")
+	}
+}
+
+func TestSuspendIdempotent(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "state.json")
+	p := NewPoller("", "")
+	p.SetStateFile(stateFile)
+
+	if err := p.SuspendStack("web"); err != nil {
+		t.Fatalf("first SuspendStack error: %v", err)
+	}
+	if err := p.SuspendStack("web"); err != nil {
+		t.Fatalf("second SuspendStack error: %v", err)
+	}
+
+	// Should appear exactly once in the suspended list.
+	if !p.IsSuspended("web") {
+		t.Fatal("web should be suspended")
+	}
+	if len(p.state.SuspendedStacks) != 1 {
+		t.Fatalf("expected 1 entry in SuspendedStacks, got %d", len(p.state.SuspendedStacks))
+	}
+}
+
+func TestResumeNotSuspended(t *testing.T) {
+	p := NewPoller("", "")
+
+	// Resume a stack that was never suspended — should be a no-op with no error.
+	if err := p.ResumeStack("ghost"); err != nil {
+		t.Fatalf("ResumeStack on non-suspended stack error: %v", err)
+	}
+	if p.IsSuspended("ghost") {
+		t.Fatal("ghost should not be suspended")
+	}
+	// needsReconcile must NOT be set for a no-op resume.
+	if p.NeedsReconcile("ghost") {
+		t.Fatal("needsReconcile should not be set for a non-suspended stack resume")
+	}
+}
+
+func TestBackwardCompatNoSuspendedField(t *testing.T) {
+	stateFile := filepath.Join(t.TempDir(), "state.json")
+
+	// Write a state file that lacks the suspended_stacks field entirely
+	// (simulating state written by an older version of dockcd).
+	oldState := map[string]interface{}{
+		"last_hash": "abc123",
+		"last_successful_commits": map[string]string{
+			"web": "abc123",
+		},
+	}
+	data, err := json.MarshalIndent(oldState, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(stateFile, data, 0644); err != nil {
+		t.Fatalf("write state file: %v", err)
+	}
+
+	p := NewPoller("", "")
+	p.SetStateFile(stateFile)
+	if err := p.LoadState(); err != nil {
+		t.Fatalf("LoadState error: %v", err)
+	}
+
+	if p.IsSuspended("web") {
+		t.Fatal("no stack should be suspended when loading old state format")
+	}
+	if len(p.state.SuspendedStacks) != 0 {
+		t.Fatalf("expected empty SuspendedStacks, got %v", p.state.SuspendedStacks)
+	}
+	if p.LastHash() != "abc123" {
+		t.Fatalf("expected LastHash=abc123, got %q", p.LastHash())
 	}
 }

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -1,0 +1,78 @@
+package hooks
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"time"
+)
+
+// DefaultTimeout is applied when Config.Timeout is zero or negative.
+const DefaultTimeout = 30 * time.Second
+
+// Config describes a hook command and its timeout.
+type Config struct {
+	Command string
+	Timeout time.Duration
+}
+
+// Env holds the DOCKCD_* environment variables injected into hook commands.
+type Env struct {
+	StackName string
+	Commit    string
+	RepoDir   string
+	Branch    string
+}
+
+// Result captures the stdout and stderr of a hook command.
+type Result struct {
+	Stdout string
+	Stderr string
+}
+
+// Run executes cfg.Command via "sh -c" in the given working directory.
+// It injects DOCKCD_* environment variables alongside the inherited parent
+// environment. The configured timeout (or DefaultTimeout) is enforced via
+// a derived context. Both stdout and stderr are captured and returned in
+// Result regardless of whether the command succeeds.
+func Run(ctx context.Context, cfg Config, dir string, env Env) (Result, error) {
+	if cfg.Command == "" {
+		return Result{}, fmt.Errorf("hooks: empty command")
+	}
+
+	timeout := cfg.Timeout
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "sh", "-c", cfg.Command)
+	cmd.Dir = dir
+
+	// Inherit parent environment and append DOCKCD_* variables.
+	cmd.Env = append(os.Environ(),
+		"DOCKCD_STACK_NAME="+env.StackName,
+		"DOCKCD_COMMIT="+env.Commit,
+		"DOCKCD_REPO_DIR="+env.RepoDir,
+		"DOCKCD_BRANCH="+env.Branch,
+	)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+
+	res := Result{
+		Stdout: stdout.String(),
+		Stderr: stderr.String(),
+	}
+
+	if err != nil {
+		return res, fmt.Errorf("hooks: command %q: %w\nstderr: %s", cfg.Command, err, res.Stderr)
+	}
+	return res, nil
+}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"syscall"
 	"time"
 )
 
@@ -51,6 +52,14 @@ func Run(ctx context.Context, cfg Config, dir string, env Env) (Result, error) {
 
 	cmd := exec.CommandContext(ctx, "sh", "-c", cfg.Command)
 	cmd.Dir = dir
+
+	// Use a process group so timeout/cancel kills the entire tree,
+	// not just the direct sh process.
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		return syscall.Kill(-cmd.Process.Pid, syscall.SIGTERM)
+	}
+	cmd.WaitDelay = 5 * time.Second
 
 	// Inherit parent environment and append DOCKCD_* variables.
 	cmd.Env = append(os.Environ(),

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -100,7 +100,7 @@ func TestRunTimeout(t *testing.T) {
 		t.Fatal("expected error, got nil")
 	}
 	if !strings.Contains(err.Error(), "context") && !strings.Contains(err.Error(), "timeout") &&
-		!strings.Contains(err.Error(), "signal: killed") {
+		!strings.Contains(err.Error(), "signal: killed") && !strings.Contains(err.Error(), "signal: terminated") {
 		t.Errorf("error = %q, want it to indicate timeout/cancellation", err.Error())
 	}
 	if elapsed > 5*time.Second {

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -1,0 +1,191 @@
+package hooks
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunSuccess(t *testing.T) {
+	cfg := Config{Command: "echo hello"}
+	env := Env{StackName: "web", Commit: "abc123", RepoDir: "/opt/repo", Branch: "main"}
+
+	res, err := Run(context.Background(), cfg, t.TempDir(), env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := strings.TrimSpace(res.Stdout); got != "hello" {
+		t.Errorf("stdout = %q, want %q", got, "hello")
+	}
+}
+
+func TestRunStdoutAndStderr(t *testing.T) {
+	cfg := Config{Command: "echo out && echo err >&2"}
+	env := Env{}
+
+	res, err := Run(context.Background(), cfg, t.TempDir(), env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(res.Stdout, "out") {
+		t.Errorf("stdout = %q, want it to contain %q", res.Stdout, "out")
+	}
+	if !strings.Contains(res.Stderr, "err") {
+		t.Errorf("stderr = %q, want it to contain %q", res.Stderr, "err")
+	}
+}
+
+func TestRunExitCode1(t *testing.T) {
+	cfg := Config{Command: "echo fail_output >&2; exit 1"}
+	env := Env{}
+
+	res, err := Run(context.Background(), cfg, t.TempDir(), env)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "exit") {
+		t.Errorf("error = %q, want it to mention exit", err.Error())
+	}
+	if !strings.Contains(res.Stderr, "fail_output") {
+		t.Errorf("stderr = %q, want it to contain %q", res.Stderr, "fail_output")
+	}
+}
+
+func TestRunEnvVarsInjected(t *testing.T) {
+	cfg := Config{Command: "echo $DOCKCD_STACK_NAME $DOCKCD_COMMIT $DOCKCD_REPO_DIR $DOCKCD_BRANCH"}
+	env := Env{StackName: "mystack", Commit: "deadbeef", RepoDir: "/srv/repo", Branch: "deploy"}
+
+	res, err := Run(context.Background(), cfg, t.TempDir(), env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := strings.TrimSpace(res.Stdout)
+	want := "mystack deadbeef /srv/repo deploy"
+	if got != want {
+		t.Errorf("stdout = %q, want %q", got, want)
+	}
+}
+
+func TestRunInheritsParentEnv(t *testing.T) {
+	const key = "DOCKCD_TEST_INHERIT_VAR"
+	const val = "inherited_value"
+	t.Setenv(key, val)
+
+	cfg := Config{Command: "echo $" + key}
+	env := Env{}
+
+	res, err := Run(context.Background(), cfg, t.TempDir(), env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := strings.TrimSpace(res.Stdout); got != val {
+		t.Errorf("stdout = %q, want %q", got, val)
+	}
+}
+
+func TestRunTimeout(t *testing.T) {
+	cfg := Config{
+		Command: "sleep 60",
+		Timeout: 100 * time.Millisecond,
+	}
+	env := Env{}
+
+	start := time.Now()
+	_, err := Run(context.Background(), cfg, t.TempDir(), env)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "context") && !strings.Contains(err.Error(), "timeout") &&
+		!strings.Contains(err.Error(), "signal: killed") {
+		t.Errorf("error = %q, want it to indicate timeout/cancellation", err.Error())
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("command took %v, expected it to be killed quickly", elapsed)
+	}
+}
+
+func TestRunContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	cfg := Config{Command: "sleep 60"}
+	env := Env{}
+
+	// Cancel after a short delay.
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := Run(ctx, cfg, t.TempDir(), env)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("command took %v, expected it to be killed quickly", elapsed)
+	}
+}
+
+func TestRunEmptyCommand(t *testing.T) {
+	cfg := Config{Command: ""}
+	env := Env{}
+
+	_, err := Run(context.Background(), cfg, t.TempDir(), env)
+	if err == nil {
+		t.Fatal("expected error for empty command, got nil")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("error = %q, want it to mention empty", err.Error())
+	}
+}
+
+func TestRunBadDirectory(t *testing.T) {
+	cfg := Config{Command: "echo hello"}
+	env := Env{}
+
+	_, err := Run(context.Background(), cfg, "/nonexistent/path/that/should/not/exist", env)
+	if err == nil {
+		t.Fatal("expected error for bad directory, got nil")
+	}
+}
+
+func TestRunDefaultTimeout(t *testing.T) {
+	// Verify that a zero timeout doesn't mean "no timeout" by checking
+	// that the command runs successfully with the default (30s is plenty
+	// for a quick echo).
+	cfg := Config{Command: "echo default_timeout_ok", Timeout: 0}
+	env := Env{}
+
+	res, err := Run(context.Background(), cfg, t.TempDir(), env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(res.Stdout, "default_timeout_ok") {
+		t.Errorf("stdout = %q, want it to contain default_timeout_ok", res.Stdout)
+	}
+}
+
+func TestRunWorkingDirectory(t *testing.T) {
+	dir := t.TempDir()
+	// Create a marker file in the temp dir.
+	if err := os.WriteFile(dir+"/marker.txt", []byte("found"), 0644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	cfg := Config{Command: "cat marker.txt"}
+	env := Env{}
+
+	res, err := Run(context.Background(), cfg, dir, env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := strings.TrimSpace(res.Stdout); got != "found" {
+		t.Errorf("stdout = %q, want %q", got, "found")
+	}
+}

--- a/internal/notify/dispatcher.go
+++ b/internal/notify/dispatcher.go
@@ -1,0 +1,94 @@
+package notify
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// NotifierWithFilter pairs a Notifier with the set of event types it should
+// receive. Events whose type is not present in the map are silently skipped
+// for that notifier.
+type NotifierWithFilter struct {
+	Notifier Notifier
+	Events   map[EventType]bool
+}
+
+// Dispatcher subscribes to an EventBus, filters events per notifier according
+// to each notifier's configured event types, and routes matching events with
+// exponential-backoff retry logic.
+type Dispatcher struct {
+	bus       *EventBus
+	logger    *slog.Logger
+	notifiers []NotifierWithFilter
+}
+
+// NewDispatcher returns a Dispatcher wired to bus. Call Start to begin
+// processing events.
+func NewDispatcher(bus *EventBus, logger *slog.Logger, notifiers []NotifierWithFilter) *Dispatcher {
+	return &Dispatcher{
+		bus:       bus,
+		logger:    logger,
+		notifiers: notifiers,
+	}
+}
+
+// Start subscribes to the EventBus and dispatches events to notifiers. It
+// blocks until ctx is cancelled or the EventBus is closed.
+func (d *Dispatcher) Start(ctx context.Context) {
+	ch := d.bus.Subscribe()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event, ok := <-ch:
+			if !ok {
+				return
+			}
+			d.dispatch(ctx, event)
+		}
+	}
+}
+
+// dispatch sends event to every notifier whose filter includes the event type.
+// Each notifier is called in its own goroutine so that a slow or retrying
+// notifier does not block others.
+func (d *Dispatcher) dispatch(ctx context.Context, event Event) {
+	for _, nf := range d.notifiers {
+		if !nf.Events[event.Type] {
+			continue
+		}
+		go d.sendWithRetry(ctx, nf.Notifier, event)
+	}
+}
+
+// sendWithRetry attempts to deliver event to n up to four times using an
+// exponential backoff schedule of 0 s, 1 s, 2 s, and 4 s between attempts.
+// It respects ctx cancellation during backoff waits.
+func (d *Dispatcher) sendWithRetry(ctx context.Context, n Notifier, event Event) {
+	backoff := []time.Duration{0, 1 * time.Second, 2 * time.Second, 4 * time.Second}
+	for attempt := 0; attempt < len(backoff); attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(backoff[attempt]):
+			}
+		}
+		if err := n.Send(ctx, event); err != nil {
+			d.logger.Warn("notification failed",
+				"notifier", n.Name(),
+				"event", string(event.Type),
+				"attempt", attempt+1,
+				"error", err,
+			)
+			continue
+		}
+		return
+	}
+	d.logger.Error("notification delivery failed after retries",
+		"notifier", n.Name(),
+		"event", string(event.Type),
+		"stack", event.Stack,
+	)
+}

--- a/internal/notify/dispatcher_test.go
+++ b/internal/notify/dispatcher_test.go
@@ -1,0 +1,287 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// testLogger returns a discarding slog.Logger suitable for tests.
+func testLogger(_ *testing.T) *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// mockNotifier records every delivered event. wg, if set, is Done once per
+// successful Send — callers can wait on it to know all expected sends arrived.
+type mockNotifier struct {
+	name   string
+	mu     sync.Mutex
+	events []Event
+	err    error
+	wg     *sync.WaitGroup
+}
+
+func (m *mockNotifier) Name() string { return m.name }
+
+func (m *mockNotifier) Send(_ context.Context, e Event) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.err != nil {
+		return m.err
+	}
+	m.events = append(m.events, e)
+	if m.wg != nil {
+		m.wg.Done()
+	}
+	return nil
+}
+
+func (m *mockNotifier) received() []Event {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]Event, len(m.events))
+	copy(out, m.events)
+	return out
+}
+
+// countingNotifier fails the first failUntil calls then succeeds, recording
+// events that pass through. wg is Done once per successful Send.
+type countingNotifier struct {
+	name      string
+	mu        sync.Mutex
+	events    []Event
+	failUntil int32
+	calls     atomic.Int32
+	wg        *sync.WaitGroup
+}
+
+func (c *countingNotifier) Name() string { return c.name }
+
+func (c *countingNotifier) Send(_ context.Context, e Event) error {
+	attempt := int(c.calls.Add(1))
+	if attempt <= int(c.failUntil) {
+		return errors.New("transient error")
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, e)
+	if c.wg != nil {
+		c.wg.Done()
+	}
+	return nil
+}
+
+func (c *countingNotifier) received() []Event {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]Event, len(c.events))
+	copy(out, c.events)
+	return out
+}
+
+// startDispatcher launches d.Start in a goroutine and waits a short time for
+// the subscription to be registered before returning. This avoids a race where
+// an Emit arrives before Start has called bus.Subscribe.
+func startDispatcher(ctx context.Context, d *Dispatcher) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		d.Start(ctx)
+	}()
+	// Give the goroutine time to reach bus.Subscribe(). Under the race
+	// detector the scheduler can be sluggish, so 50 ms is sufficient without
+	// being noisy in CI.
+	time.Sleep(50 * time.Millisecond)
+	return done
+}
+
+// TestDispatcherRoutesEvents verifies that each notifier receives only the
+// event types it has subscribed to.
+func TestDispatcherRoutesEvents(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	t.Cleanup(bus.Close)
+
+	var wg sync.WaitGroup
+	// Expect successNotifier to receive 1 event, failureNotifier to receive 2.
+	wg.Add(3)
+
+	successNotifier := &mockNotifier{name: "success-only", wg: &wg}
+	failureNotifier := &mockNotifier{name: "failure-only", wg: &wg}
+
+	d := NewDispatcher(bus, testLogger(t), []NotifierWithFilter{
+		{
+			Notifier: successNotifier,
+			Events:   map[EventType]bool{EventDeploySuccess: true},
+		},
+		{
+			Notifier: failureNotifier,
+			Events:   map[EventType]bool{EventDeployFailure: true, EventRollbackFailure: true},
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := startDispatcher(ctx, d)
+
+	bus.Emit(Event{Type: EventDeploySuccess, Stack: "s1"})
+	bus.Emit(Event{Type: EventDeployFailure, Stack: "s2"})
+	bus.Emit(Event{Type: EventRollbackFailure, Stack: "s3"})
+
+	// Wait for all three sends to complete (with a safety timeout).
+	waitCh := make(chan struct{})
+	go func() { wg.Wait(); close(waitCh) }()
+	select {
+	case <-waitCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for all notifications to be delivered")
+	}
+
+	cancel()
+	<-done
+
+	gotSuccess := successNotifier.received()
+	if len(gotSuccess) != 1 {
+		t.Fatalf("success notifier: want 1 event, got %d", len(gotSuccess))
+	}
+	if gotSuccess[0].Type != EventDeploySuccess {
+		t.Errorf("success notifier: want deploy_success, got %s", gotSuccess[0].Type)
+	}
+
+	gotFailure := failureNotifier.received()
+	if len(gotFailure) != 2 {
+		t.Fatalf("failure notifier: want 2 events, got %d", len(gotFailure))
+	}
+}
+
+// TestDispatcherStopsOnContextCancel verifies Start returns when the context
+// is cancelled.
+func TestDispatcherStopsOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	t.Cleanup(bus.Close)
+
+	d := NewDispatcher(bus, testLogger(t), nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := startDispatcher(ctx, d)
+
+	cancel()
+
+	select {
+	case <-done:
+		// expected
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after context cancellation")
+	}
+}
+
+// TestDispatcherStopsOnBusClose verifies Start returns when the EventBus is
+// closed.
+func TestDispatcherStopsOnBusClose(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+
+	d := NewDispatcher(bus, testLogger(t), nil)
+
+	done := startDispatcher(context.Background(), d)
+
+	bus.Close()
+
+	select {
+	case <-done:
+		// expected
+	case <-time.After(2 * time.Second):
+		t.Fatal("Start did not return after bus was closed")
+	}
+}
+
+// TestDispatcherRetriesOnFailure verifies that a transient notifier error
+// triggers exponential-backoff retries and the event is ultimately delivered.
+// This test takes ~3 s due to the backoff schedule (0 s + 1 s + 2 s).
+func TestDispatcherRetriesOnFailure(t *testing.T) {
+	bus := NewEventBus()
+	t.Cleanup(bus.Close)
+
+	var wg sync.WaitGroup
+	wg.Add(1) // one successful delivery expected
+
+	n := &countingNotifier{name: "flaky", failUntil: 2, wg: &wg}
+
+	d := NewDispatcher(bus, testLogger(t), []NotifierWithFilter{
+		{
+			Notifier: n,
+			Events:   map[EventType]bool{EventDeploySuccess: true},
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := startDispatcher(ctx, d)
+	_ = done
+
+	bus.Emit(Event{Type: EventDeploySuccess, Stack: "retry-stack"})
+
+	// Backoff schedule: attempt 1 = 0 s, attempt 2 = 1 s, attempt 3 = 2 s.
+	// Allow generous wall-clock budget.
+	waitCh := make(chan struct{})
+	go func() { wg.Wait(); close(waitCh) }()
+	select {
+	case <-waitCh:
+	case <-time.After(6 * time.Second):
+		t.Fatalf("event not delivered after retries; calls=%d received=%d",
+			n.calls.Load(), len(n.received()))
+	}
+
+	if got := n.calls.Load(); got != 3 {
+		t.Errorf("want 3 Send calls (2 failures + 1 success), got %d", got)
+	}
+}
+
+// TestDispatcherSkipsUnfilteredEvents verifies that a notifier does not
+// receive event types outside its filter.
+func TestDispatcherSkipsUnfilteredEvents(t *testing.T) {
+	t.Parallel()
+
+	bus := NewEventBus()
+	t.Cleanup(bus.Close)
+
+	n := &mockNotifier{name: "failure-only"}
+
+	d := NewDispatcher(bus, testLogger(t), []NotifierWithFilter{
+		{
+			Notifier: n,
+			Events:   map[EventType]bool{EventDeployFailure: true},
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := startDispatcher(ctx, d)
+
+	// Emit an event the notifier is NOT subscribed to.
+	bus.Emit(Event{Type: EventDeploySuccess, Stack: "should-be-ignored"})
+
+	// Give the dispatcher time to process the event (and confirm no send
+	// happens). Under the race detector 200 ms is sufficient.
+	time.Sleep(200 * time.Millisecond)
+
+	cancel()
+	<-done
+
+	if got := len(n.received()); got != 0 {
+		t.Errorf("want 0 events for unfiltered type, got %d", got)
+	}
+}

--- a/internal/notify/event.go
+++ b/internal/notify/event.go
@@ -1,0 +1,106 @@
+// Package notify provides an in-process event bus for distributing lifecycle
+// events to subscribers such as SSE endpoints and notification dispatchers.
+package notify
+
+import (
+	"sync"
+	"time"
+)
+
+// EventType identifies the kind of lifecycle event.
+type EventType string
+
+const (
+	EventDeploySuccess     EventType = "deploy_success"
+	EventDeployFailure     EventType = "deploy_failure"
+	EventRollbackSuccess   EventType = "rollback_success"
+	EventRollbackFailure   EventType = "rollback_failure"
+	EventReconcileStart    EventType = "reconcile_start"
+	EventReconcileComplete EventType = "reconcile_complete"
+	EventForceDeploy       EventType = "force_deploy"
+	EventStackSuspended    EventType = "stack_suspended"
+	EventStackResumed      EventType = "stack_resumed"
+	EventHookFailure       EventType = "hook_failure"
+)
+
+// Event carries information about a single lifecycle occurrence.
+type Event struct {
+	Type      EventType         `json:"type"`
+	Timestamp time.Time         `json:"timestamp"`
+	Stack     string            `json:"stack,omitempty"`
+	Host      string            `json:"host,omitempty"`
+	Commit    string            `json:"commit,omitempty"`
+	Branch    string            `json:"branch,omitempty"`
+	Message   string            `json:"message,omitempty"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+}
+
+// subscriberBuffer is the capacity of each subscriber's channel. A slow
+// subscriber will have events dropped rather than blocking Emit or other
+// subscribers.
+const subscriberBuffer = 64
+
+// EventBus distributes events to all current subscribers. All methods are
+// safe for concurrent use.
+type EventBus struct {
+	mu          sync.RWMutex
+	subscribers []chan Event
+	closed      bool
+}
+
+// NewEventBus returns an initialised, open EventBus.
+func NewEventBus() *EventBus {
+	return &EventBus{}
+}
+
+// Subscribe returns a buffered channel that receives every event emitted
+// after the call returns. If the bus is already closed, the returned channel
+// is already closed.
+func (b *EventBus) Subscribe() <-chan Event {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	ch := make(chan Event, subscriberBuffer)
+	if b.closed {
+		close(ch)
+		return ch
+	}
+	b.subscribers = append(b.subscribers, ch)
+	return ch
+}
+
+// Emit sends event to every subscriber using a non-blocking send. If a
+// subscriber's buffer is full the event is silently dropped for that
+// subscriber. Emit is a no-op when the bus is closed.
+func (b *EventBus) Emit(event Event) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	if b.closed {
+		return
+	}
+	for _, ch := range b.subscribers {
+		select {
+		case ch <- event:
+		default:
+			// Subscriber buffer full; drop the event for this subscriber.
+		}
+	}
+}
+
+// Close closes all subscriber channels and marks the bus as closed.
+// Subsequent calls to Close are no-ops. Subsequent calls to Emit are no-ops.
+// Subsequent calls to Subscribe return an already-closed channel.
+func (b *EventBus) Close() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.closed {
+		return
+	}
+	b.closed = true
+	for _, ch := range b.subscribers {
+		close(ch)
+	}
+	b.subscribers = nil
+}

--- a/internal/notify/event_test.go
+++ b/internal/notify/event_test.go
@@ -1,0 +1,171 @@
+package notify
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestEventBusEmitToSubscriber(t *testing.T) {
+	bus := NewEventBus()
+	ch := bus.Subscribe()
+
+	want := Event{
+		Type:   EventDeploySuccess,
+		Stack:  "mystack",
+		Commit: "abc123",
+	}
+	bus.Emit(want)
+
+	select {
+	case got := <-ch:
+		if got.Type != want.Type || got.Stack != want.Stack || got.Commit != want.Commit {
+			t.Errorf("got %+v, want %+v", got, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event")
+	}
+}
+
+func TestEventBusMultipleSubscribers(t *testing.T) {
+	bus := NewEventBus()
+	ch1 := bus.Subscribe()
+	ch2 := bus.Subscribe()
+
+	event := Event{Type: EventRollbackSuccess, Stack: "stack1"}
+	bus.Emit(event)
+
+	for i, ch := range []<-chan Event{ch1, ch2} {
+		select {
+		case got := <-ch:
+			if got.Type != event.Type {
+				t.Errorf("subscriber %d: got type %q, want %q", i, got.Type, event.Type)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("subscriber %d: timed out waiting for event", i)
+		}
+	}
+}
+
+func TestEventBusEmitNoSubscribers(t *testing.T) {
+	bus := NewEventBus()
+	// Must not panic or block.
+	bus.Emit(Event{Type: EventReconcileStart})
+}
+
+func TestEventBusCloseClosesChannels(t *testing.T) {
+	bus := NewEventBus()
+	ch := bus.Subscribe()
+
+	bus.Close()
+
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Error("expected channel to be closed, but received a value")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for channel to be closed")
+	}
+}
+
+func TestEventBusEmitAfterClose(t *testing.T) {
+	bus := NewEventBus()
+	_ = bus.Subscribe()
+	bus.Close()
+
+	// Must not panic.
+	bus.Emit(Event{Type: EventDeployFailure})
+}
+
+func TestEventBusSlowSubscriberDoesNotBlock(t *testing.T) {
+	bus := NewEventBus()
+	slow := bus.Subscribe()
+	fast := bus.Subscribe()
+
+	// Fill the slow subscriber's buffer completely.
+	for i := 0; i < subscriberBuffer; i++ {
+		bus.Emit(Event{Type: EventReconcileComplete, Message: "fill"})
+	}
+
+	// The fast subscriber should have received all events.
+	for i := 0; i < subscriberBuffer; i++ {
+		select {
+		case <-fast:
+		case <-time.After(time.Second):
+			t.Fatalf("fast subscriber timed out on event %d", i)
+		}
+	}
+
+	// One more emit should not block even though slow's buffer is full.
+	done := make(chan struct{})
+	go func() {
+		bus.Emit(Event{Type: EventForceDeploy})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Emit blocked with a full slow subscriber")
+	}
+
+	// Drain slow to avoid goroutine leak in test.
+	for len(slow) > 0 {
+		<-slow
+	}
+}
+
+func TestEventBusSubscribeAfterClose(t *testing.T) {
+	bus := NewEventBus()
+	bus.Close()
+
+	ch := bus.Subscribe()
+
+	select {
+	case _, ok := <-ch:
+		if ok {
+			t.Error("expected already-closed channel, got open channel with value")
+		}
+	default:
+		// Channel should be closed; a closed channel is always ready to receive.
+		t.Error("expected closed channel to be immediately readable")
+	}
+}
+
+func TestEventBusCloseIdempotent(t *testing.T) {
+	bus := NewEventBus()
+	_ = bus.Subscribe()
+
+	// Must not panic on double close.
+	bus.Close()
+	bus.Close()
+}
+
+func TestEventBusConcurrentEmitSubscribeClose(t *testing.T) {
+	bus := NewEventBus()
+
+	var wg sync.WaitGroup
+
+	// Concurrent subscribers.
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = bus.Subscribe()
+		}()
+	}
+
+	// Concurrent emitters.
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			bus.Emit(Event{Type: EventDeploySuccess})
+		}()
+	}
+
+	wg.Wait()
+	// Close should not panic regardless of concurrent activity.
+	bus.Close()
+}

--- a/internal/notify/notifier.go
+++ b/internal/notify/notifier.go
@@ -1,0 +1,98 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Notifier delivers events to an external system.
+type Notifier interface {
+	// Name returns the human-readable identifier for this notifier.
+	Name() string
+	// Send delivers the event to the external system. It returns an error if
+	// delivery fails.
+	Send(ctx context.Context, event Event) error
+}
+
+// webhookPayload is the JSON body sent by WebhookNotifier.
+type webhookPayload struct {
+	Event     string            `json:"event"`
+	Timestamp time.Time         `json:"timestamp"`
+	Stack     string            `json:"stack,omitempty"`
+	Host      string            `json:"host,omitempty"`
+	Commit    string            `json:"commit,omitempty"`
+	Branch    string            `json:"branch,omitempty"`
+	Message   string            `json:"message,omitempty"`
+	Metadata  map[string]string `json:"metadata"`
+}
+
+// WebhookNotifier POSTs a JSON payload to a configured URL for each event.
+type WebhookNotifier struct {
+	name   string
+	url    string
+	client *http.Client
+}
+
+// NewWebhookNotifier returns a WebhookNotifier that delivers events to url.
+// The name is used in error messages and returned by Name.
+func NewWebhookNotifier(name, url string) *WebhookNotifier {
+	return &WebhookNotifier{
+		name: name,
+		url:  url,
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+// Name returns the configured notifier name.
+func (w *WebhookNotifier) Name() string {
+	return w.name
+}
+
+// Send marshals event into a JSON payload and POSTs it to the configured URL.
+// It returns nil on a 2xx response, and a descriptive error otherwise.
+func (w *WebhookNotifier) Send(ctx context.Context, event Event) error {
+	meta := event.Metadata
+	if meta == nil {
+		meta = map[string]string{}
+	}
+
+	payload := webhookPayload{
+		Event:     string(event.Type),
+		Timestamp: event.Timestamp,
+		Stack:     event.Stack,
+		Host:      event.Host,
+		Commit:    event.Commit,
+		Branch:    event.Branch,
+		Message:   event.Message,
+		Metadata:  meta,
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("notifier %q: marshal payload: %w", w.name, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("notifier %q: create request: %w", w.name, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := w.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("notifier %q: send request: %w", w.name, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("notifier %q: unexpected status %d", w.name, resp.StatusCode)
+	}
+
+	return nil
+}

--- a/internal/notify/notifier.go
+++ b/internal/notify/notifier.go
@@ -96,3 +96,103 @@ func (w *WebhookNotifier) Send(ctx context.Context, event Event) error {
 
 	return nil
 }
+
+// slackAttachment is a single Slack message attachment.
+type slackAttachment struct {
+	Color string `json:"color"`
+	Text  string `json:"text"`
+	Ts    int64  `json:"ts"`
+}
+
+// slackEnvelope is the JSON body sent to a Slack incoming webhook.
+type slackEnvelope struct {
+	Attachments []slackAttachment `json:"attachments"`
+}
+
+// SlackNotifier posts a formatted message to a Slack incoming webhook URL.
+type SlackNotifier struct {
+	name   string
+	url    string
+	client *http.Client
+}
+
+// NewSlackNotifier returns a SlackNotifier that delivers events to the given
+// Slack incoming webhook url. name is used in error messages and returned by
+// Name.
+func NewSlackNotifier(name, url string) *SlackNotifier {
+	return &SlackNotifier{
+		name: name,
+		url:  url,
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+// Name returns the configured notifier name.
+func (s *SlackNotifier) Name() string {
+	return s.name
+}
+
+// Send formats event as a Slack attachment and POSTs it to the configured
+// webhook URL. It returns nil on a 2xx response, and a descriptive error
+// otherwise.
+func (s *SlackNotifier) Send(ctx context.Context, event Event) error {
+	commit := event.Commit
+	if len(commit) > 7 {
+		commit = commit[:7]
+	}
+
+	text := fmt.Sprintf("*%s* | stack: `%s` | branch: `%s` | host: `%s` | commit: `%s`",
+		event.Type, event.Stack, event.Branch, event.Host, commit)
+	if event.Message != "" {
+		text += fmt.Sprintf("\n```%s```", event.Message)
+	}
+
+	envelope := slackEnvelope{
+		Attachments: []slackAttachment{
+			{
+				Color: slackColor(event.Type),
+				Text:  text,
+				Ts:    event.Timestamp.Unix(),
+			},
+		},
+	}
+
+	body, err := json.Marshal(envelope)
+	if err != nil {
+		return fmt.Errorf("notifier %q: marshal payload: %w", s.name, err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("notifier %q: create request: %w", s.name, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("notifier %q: send request: %w", s.name, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("notifier %q: unexpected status %d", s.name, resp.StatusCode)
+	}
+
+	return nil
+}
+
+// slackColor maps an EventType to a Slack attachment color string.
+func slackColor(et EventType) string {
+	switch et {
+	case EventDeploySuccess, EventReconcileComplete, EventStackResumed:
+		return "good"
+	case EventDeployFailure, EventRollbackFailure, EventHookFailure:
+		return "danger"
+	case EventRollbackSuccess, EventStackSuspended, EventForceDeploy:
+		return "warning"
+	default:
+		return "#439FE0"
+	}
+}

--- a/internal/notify/notifier_test.go
+++ b/internal/notify/notifier_test.go
@@ -1,0 +1,116 @@
+package notify
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"context"
+)
+
+func TestWebhookNotifierName(t *testing.T) {
+	n := NewWebhookNotifier("my-webhook", "http://example.com/hook")
+	if got := n.Name(); got != "my-webhook" {
+		t.Errorf("Name() = %q, want %q", got, "my-webhook")
+	}
+}
+
+func TestWebhookNotifierSend(t *testing.T) {
+	var (
+		gotMethod      string
+		gotContentType string
+		gotBody        map[string]interface{}
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotContentType = r.Header.Get("Content-Type")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ts, _ := time.Parse(time.RFC3339, "2026-04-04T12:00:00Z")
+	event := Event{
+		Type:      EventDeployFailure,
+		Timestamp: ts,
+		Stack:     "traefik",
+		Host:      "server04",
+		Commit:    "abc123",
+		Branch:    "main",
+		Message:   "health check timed out",
+		Metadata:  map[string]string{"key": "val"},
+	}
+
+	n := NewWebhookNotifier("test-hook", srv.URL)
+	if err := n.Send(context.Background(), event); err != nil {
+		t.Fatalf("Send() unexpected error: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", gotMethod)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", gotContentType)
+	}
+
+	checks := map[string]string{
+		"event":   string(EventDeployFailure),
+		"stack":   "traefik",
+		"host":    "server04",
+		"commit":  "abc123",
+		"branch":  "main",
+		"message": "health check timed out",
+	}
+	for field, want := range checks {
+		got, ok := gotBody[field]
+		if !ok {
+			t.Errorf("payload missing field %q", field)
+			continue
+		}
+		if got.(string) != want {
+			t.Errorf("payload[%q] = %q, want %q", field, got, want)
+		}
+	}
+
+	// timestamp must be present and parseable as RFC3339
+	rawTS, ok := gotBody["timestamp"]
+	if !ok {
+		t.Fatal("payload missing field \"timestamp\"")
+	}
+	if _, err := time.Parse(time.RFC3339, rawTS.(string)); err != nil {
+		t.Errorf("timestamp %q is not RFC3339: %v", rawTS, err)
+	}
+}
+
+func TestWebhookNotifierNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	n := NewWebhookNotifier("failing-hook", srv.URL)
+	err := n.Send(context.Background(), Event{Type: EventDeployFailure})
+	if err == nil {
+		t.Fatal("Send() expected error on 500 response, got nil")
+	}
+}
+
+func TestWebhookNotifierNetworkError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	// Close the server before making the request to simulate a network error.
+	srv.Close()
+
+	n := NewWebhookNotifier("dead-hook", srv.URL)
+	err := n.Send(context.Background(), Event{Type: EventDeployFailure})
+	if err == nil {
+		t.Fatal("Send() expected error on closed server, got nil")
+	}
+}

--- a/internal/notify/notifier_test.go
+++ b/internal/notify/notifier_test.go
@@ -114,3 +114,134 @@ func TestWebhookNotifierNetworkError(t *testing.T) {
 		t.Fatal("Send() expected error on closed server, got nil")
 	}
 }
+
+// testSlackAttachment mirrors the JSON shape sent in attachments[0].
+type testSlackAttachment struct {
+	Color string  `json:"color"`
+	Text  string  `json:"text"`
+	Ts    float64 `json:"ts"`
+}
+
+type testSlackPayload struct {
+	Attachments []testSlackAttachment `json:"attachments"`
+}
+
+func newSlackTestServer(t *testing.T) (*httptest.Server, *testSlackPayload) {
+	t.Helper()
+	got := &testSlackPayload{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(got); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, got
+}
+
+func TestSlackNotifierName(t *testing.T) {
+	n := NewSlackNotifier("slack-prod", "http://example.com/slack")
+	if got := n.Name(); got != "slack-prod" {
+		t.Errorf("Name() = %q, want %q", got, "slack-prod")
+	}
+}
+
+func TestSlackNotifierSend(t *testing.T) {
+	srv, got := newSlackTestServer(t)
+
+	ts, _ := time.Parse(time.RFC3339, "2026-04-04T12:00:00Z")
+	event := Event{
+		Type:      EventDeploySuccess,
+		Timestamp: ts,
+		Stack:     "traefik",
+		Host:      "server04",
+		Commit:    "abc123f",
+		Branch:    "main",
+	}
+
+	n := NewSlackNotifier("slack-test", srv.URL)
+	if err := n.Send(context.Background(), event); err != nil {
+		t.Fatalf("Send() unexpected error: %v", err)
+	}
+
+	if len(got.Attachments) == 0 {
+		t.Fatal("payload has no attachments")
+	}
+	att := got.Attachments[0]
+	if att.Color != "good" {
+		t.Errorf("color = %q, want %q", att.Color, "good")
+	}
+	if att.Text == "" {
+		t.Error("attachment text is empty")
+	}
+}
+
+func TestSlackNotifierFailureColor(t *testing.T) {
+	srv, got := newSlackTestServer(t)
+
+	n := NewSlackNotifier("slack-test", srv.URL)
+	if err := n.Send(context.Background(), Event{Type: EventDeployFailure}); err != nil {
+		t.Fatalf("Send() unexpected error: %v", err)
+	}
+
+	if len(got.Attachments) == 0 {
+		t.Fatal("payload has no attachments")
+	}
+	if got.Attachments[0].Color != "danger" {
+		t.Errorf("color = %q, want %q", got.Attachments[0].Color, "danger")
+	}
+}
+
+func TestSlackNotifierRollbackColor(t *testing.T) {
+	srv, got := newSlackTestServer(t)
+
+	n := NewSlackNotifier("slack-test", srv.URL)
+	if err := n.Send(context.Background(), Event{Type: EventRollbackSuccess}); err != nil {
+		t.Fatalf("Send() unexpected error: %v", err)
+	}
+
+	if len(got.Attachments) == 0 {
+		t.Fatal("payload has no attachments")
+	}
+	if got.Attachments[0].Color != "warning" {
+		t.Errorf("color = %q, want %q", got.Attachments[0].Color, "warning")
+	}
+}
+
+func TestSlackNotifierCommitTruncated(t *testing.T) {
+	srv, got := newSlackTestServer(t)
+
+	n := NewSlackNotifier("slack-test", srv.URL)
+	event := Event{
+		Type:   EventDeploySuccess,
+		Commit: "abc123fdeadbeef",
+	}
+	if err := n.Send(context.Background(), event); err != nil {
+		t.Fatalf("Send() unexpected error: %v", err)
+	}
+
+	if len(got.Attachments) == 0 {
+		t.Fatal("payload has no attachments")
+	}
+	text := got.Attachments[0].Text
+	// The full commit must not appear; the 7-char prefix must appear.
+	if contains(text, "abc123fdeadbeef") {
+		t.Errorf("text contains full commit hash, expected truncation: %q", text)
+	}
+	if !contains(text, "abc123f") {
+		t.Errorf("text does not contain 7-char commit prefix %q: %q", "abc123f", text)
+	}
+}
+
+// contains is a simple substring helper to avoid importing strings in tests.
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && func() bool {
+		for i := 0; i <= len(s)-len(sub); i++ {
+			if s[i:i+len(sub)] == sub {
+				return true
+			}
+		}
+		return false
+	}()
+}

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/mohitsharma44/dockcd/internal/deploy"
 	"github.com/mohitsharma44/dockcd/internal/hooks"
 	"github.com/mohitsharma44/dockcd/internal/metrics"
+	"github.com/mohitsharma44/dockcd/internal/notify"
 	"github.com/mohitsharma44/dockcd/internal/server"
 )
 
@@ -57,6 +59,7 @@ type Config struct {
 	Metrics      *metrics.Metrics
 	Status       *server.Status
 	Logger       *slog.Logger
+	EventBus     *notify.EventBus // optional; nil disables event emission
 }
 
 // Reconciler is the core loop that polls git for changes and deploys
@@ -74,6 +77,7 @@ type Reconciler struct {
 	metrics      *metrics.Metrics
 	status       *server.Status
 	logger       *slog.Logger
+	eventBus     *notify.EventBus
 }
 
 // New creates a Reconciler from the given config. Returns an error if
@@ -109,6 +113,7 @@ func New(cfg Config) (*Reconciler, error) {
 		metrics:      cfg.Metrics,
 		status:       cfg.Status,
 		logger:       logger,
+		eventBus:     cfg.EventBus,
 	}, nil
 }
 
@@ -164,6 +169,7 @@ func (r *Reconciler) initRepo() error {
 // reconcile performs a single poll-and-deploy cycle.
 func (r *Reconciler) reconcile(ctx context.Context) error {
 	prevHash := r.poller.LastHash()
+	r.emit(notify.EventReconcileStart, "", prevHash, "reconcile started")
 
 	changed, err := r.poller.Fetch()
 	if err != nil {
@@ -173,6 +179,7 @@ func (r *Reconciler) reconcile(ctx context.Context) error {
 
 	if !changed {
 		r.recordPollMetric(ctx, "unchanged")
+		r.emit(notify.EventReconcileComplete, "", prevHash, "no changes")
 		return nil
 	}
 
@@ -224,6 +231,7 @@ func (r *Reconciler) reconcile(ctx context.Context) error {
 			"duration", duration,
 			"stacks", changedNames,
 		)
+		r.emit(notify.EventReconcileComplete, "", commitHash, "deploy complete with rollbacks")
 		return nil
 	}
 
@@ -233,6 +241,7 @@ func (r *Reconciler) reconcile(ctx context.Context) error {
 		"duration", duration,
 		"stacks", changedNames,
 	)
+	r.emit(notify.EventReconcileComplete, "", commitHash, "deploy complete")
 
 	return nil
 }
@@ -283,6 +292,7 @@ func (r *Reconciler) deployStack(ctx context.Context, stack deploy.Stack, commit
 	}
 	if err := deploy.Deploy(ctx, stack, r.repoDir, r.runner, env); err != nil {
 		r.markStackHealth(ctx, stack.Name, false)
+		r.emit(notify.EventDeployFailure, stack.Name, commitHash, err.Error())
 		return err
 	}
 
@@ -307,6 +317,7 @@ func (r *Reconciler) deployStack(ctx context.Context, stack deploy.Stack, commit
 		r.logger.Error("failed to save last successful commit", "stack", stack.Name, "error", err)
 	}
 	r.markStackHealth(ctx, stack.Name, true)
+	r.emit(notify.EventDeploySuccess, stack.Name, commitHash, "deploy succeeded")
 	return nil
 }
 
@@ -316,11 +327,13 @@ func (r *Reconciler) rollback(ctx context.Context, stack deploy.Stack, currentCo
 	if lastGood == "" {
 		r.markStackHealth(ctx, stack.Name, false)
 		r.recordRollbackMetric(ctx, stack.Name, "failure")
+		r.emit(notify.EventRollbackFailure, stack.Name, currentCommit, "no previous successful commit")
 		return fmt.Errorf("stack %q: no previous successful commit to rollback to", stack.Name)
 	}
 	if lastGood == currentCommit {
 		r.markStackHealth(ctx, stack.Name, false)
 		r.recordRollbackMetric(ctx, stack.Name, "failure")
+		r.emit(notify.EventRollbackFailure, stack.Name, currentCommit, "current commit is the last successful commit")
 		return fmt.Errorf("stack %q: current commit IS the last successful commit", stack.Name)
 	}
 
@@ -334,6 +347,7 @@ func (r *Reconciler) rollback(ctx context.Context, stack deploy.Stack, currentCo
 	if err != nil {
 		r.markStackHealth(ctx, stack.Name, false)
 		r.recordRollbackMetric(ctx, stack.Name, "failure")
+		r.emit(notify.EventRollbackFailure, stack.Name, currentCommit, err.Error())
 		return fmt.Errorf("creating temp dir for rollback: %w", err)
 	}
 	defer os.RemoveAll(tmpDir)
@@ -341,6 +355,7 @@ func (r *Reconciler) rollback(ctx context.Context, stack deploy.Stack, currentCo
 	if err := r.poller.ExtractAtCommit(lastGood, stack.Path, tmpDir); err != nil {
 		r.markStackHealth(ctx, stack.Name, false)
 		r.recordRollbackMetric(ctx, stack.Name, "failure")
+		r.emit(notify.EventRollbackFailure, stack.Name, currentCommit, err.Error())
 		return fmt.Errorf("extracting files at %s: %w", lastGood, err)
 	}
 
@@ -354,12 +369,14 @@ func (r *Reconciler) rollback(ctx context.Context, stack deploy.Stack, currentCo
 	}); err != nil {
 		r.markStackHealth(ctx, stack.Name, false)
 		r.recordRollbackMetric(ctx, stack.Name, "failure")
+		r.emit(notify.EventRollbackFailure, stack.Name, currentCommit, err.Error())
 		return fmt.Errorf("rollback deploy failed for %q: %w", stack.Name, err)
 	}
 
 	// Rollback succeeded — stack is running but degraded (not at HEAD).
 	r.markStackHealth(ctx, stack.Name, false)
 	r.recordRollbackMetric(ctx, stack.Name, "success")
+	r.emit(notify.EventRollbackSuccess, stack.Name, lastGood, "rolled back to "+lastGood)
 	r.logger.Warn("rollback complete, stack is degraded",
 		"stack", stack.Name, "running_commit", lastGood)
 	return fmt.Errorf("stack %q: %w to %s", stack.Name, ErrRolledBack, lastGood)
@@ -534,4 +551,96 @@ func (r *Reconciler) recordRollbackMetric(ctx context.Context, stackName, result
 			attribute.String("result", result),
 		),
 	)
+}
+
+// --- Async trigger methods (satisfy server.ReconcileTriggerer) ---
+
+// TriggerReconcile triggers an async reconcile for a single named stack.
+// Returns a unique reconcile ID and an error if the stack is unknown or
+// suspended. The actual deploy runs in a background goroutine.
+func (r *Reconciler) TriggerReconcile(ctx context.Context, stackName string) (string, error) {
+	var found bool
+	for _, s := range r.hostStacks {
+		if s.Name == stackName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return "", fmt.Errorf("stack %q not found", stackName)
+	}
+	if r.poller.IsSuspended(stackName) {
+		return "", fmt.Errorf("stack %q is suspended", stackName)
+	}
+
+	id := "rec-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+
+	go func() {
+		r.logger.Info("force reconcile triggered", "stack", stackName, "id", id)
+		if _, err := r.poller.Fetch(); err != nil {
+			r.logger.Error("force reconcile fetch failed", "error", err)
+			return
+		}
+		stacks := r.filterStackByName(stackName)
+		if len(stacks) == 0 {
+			return
+		}
+		groups, err := deploy.BuildGraph(stacks)
+		if err != nil {
+			r.logger.Error("force reconcile graph failed", "error", err)
+			return
+		}
+		commitHash := r.poller.LastHash()
+		if err := r.deployGroups(ctx, groups, commitHash); err != nil && !errors.Is(err, ErrRolledBack) {
+			r.logger.Error("force reconcile failed", "error", err)
+		}
+		r.status.Update(time.Now(), commitHash)
+	}()
+
+	return id, nil
+}
+
+// TriggerReconcileAll triggers an async reconcile for all configured stacks.
+// Returns a unique reconcile ID. The actual deploy runs in a background goroutine.
+func (r *Reconciler) TriggerReconcileAll(ctx context.Context) (string, error) {
+	id := "rec-" + strconv.FormatInt(time.Now().UnixNano(), 10)
+
+	go func() {
+		r.logger.Info("force reconcile all triggered", "id", id)
+		if _, err := r.poller.Fetch(); err != nil {
+			r.logger.Error("force reconcile fetch failed", "error", err)
+			return
+		}
+		if err := r.deployAll(ctx); err != nil {
+			r.logger.Error("force reconcile deploy failed", "error", err)
+		}
+		r.status.Update(time.Now(), r.poller.LastHash())
+	}()
+
+	return id, nil
+}
+
+// filterStackByName returns deploy stacks for a single named config stack.
+func (r *Reconciler) filterStackByName(name string) []deploy.Stack {
+	for _, cs := range r.hostStacks {
+		if cs.Name == name {
+			return r.configToDeployStacks([]config.Stack{cs})
+		}
+	}
+	return nil
+}
+
+// emit sends an event to the EventBus. It is a no-op when eventBus is nil.
+func (r *Reconciler) emit(eventType notify.EventType, stack, commit, msg string) {
+	if r.eventBus == nil {
+		return
+	}
+	r.eventBus.Emit(notify.Event{
+		Type:      eventType,
+		Timestamp: time.Now(),
+		Stack:     stack,
+		Host:      r.hostname,
+		Commit:    commit,
+		Message:   msg,
+	})
 }

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -47,37 +47,39 @@ type GitPoller interface {
 
 // Config holds all dependencies for the Reconciler.
 type Config struct {
-	Poller       GitPoller
-	HostStacks   []config.Stack
-	Hostname     string
-	BasePath     string
-	RepoDir      string
-	PollInterval time.Duration
-	InitialSync  bool
-	Runner       deploy.CommandRunner
-	OutputRunner deploy.OutputRunner
-	Metrics      *metrics.Metrics
-	Status       *server.Status
-	Logger       *slog.Logger
-	EventBus     *notify.EventBus // optional; nil disables event emission
+	Poller        GitPoller
+	HostStacks    []config.Stack
+	Hostname      string
+	BasePath      string
+	RepoDir       string
+	DefaultBranch string
+	PollInterval  time.Duration
+	InitialSync   bool
+	Runner        deploy.CommandRunner
+	OutputRunner  deploy.OutputRunner
+	Metrics       *metrics.Metrics
+	Status        *server.Status
+	Logger        *slog.Logger
+	EventBus      *notify.EventBus // optional; nil disables event emission
 }
 
 // Reconciler is the core loop that polls git for changes and deploys
 // affected stacks in dependency order.
 type Reconciler struct {
-	poller       GitPoller
-	hostStacks   []config.Stack
-	hostname     string
-	basePath     string
-	repoDir      string
-	pollInterval time.Duration
-	initialSync  bool
-	runner       deploy.CommandRunner
-	outputRunner deploy.OutputRunner
-	metrics      *metrics.Metrics
-	status       *server.Status
-	logger       *slog.Logger
-	eventBus     *notify.EventBus
+	poller        GitPoller
+	hostStacks    []config.Stack
+	hostname      string
+	basePath      string
+	repoDir       string
+	defaultBranch string
+	pollInterval  time.Duration
+	initialSync   bool
+	runner        deploy.CommandRunner
+	outputRunner  deploy.OutputRunner
+	metrics       *metrics.Metrics
+	status        *server.Status
+	logger        *slog.Logger
+	eventBus      *notify.EventBus
 }
 
 // New creates a Reconciler from the given config. Returns an error if
@@ -101,19 +103,20 @@ func New(cfg Config) (*Reconciler, error) {
 		logger = slog.Default()
 	}
 	return &Reconciler{
-		poller:       cfg.Poller,
-		hostStacks:   cfg.HostStacks,
-		hostname:     cfg.Hostname,
-		basePath:     cfg.BasePath,
-		repoDir:      cfg.RepoDir,
-		pollInterval: cfg.PollInterval,
-		initialSync:  cfg.InitialSync,
-		runner:       cfg.Runner,
-		outputRunner: cfg.OutputRunner,
-		metrics:      cfg.Metrics,
-		status:       cfg.Status,
-		logger:       logger,
-		eventBus:     cfg.EventBus,
+		poller:        cfg.Poller,
+		hostStacks:    cfg.HostStacks,
+		hostname:      cfg.Hostname,
+		basePath:      cfg.BasePath,
+		repoDir:       cfg.RepoDir,
+		defaultBranch: cfg.DefaultBranch,
+		pollInterval:  cfg.PollInterval,
+		initialSync:   cfg.InitialSync,
+		runner:        cfg.Runner,
+		outputRunner:  cfg.OutputRunner,
+		metrics:       cfg.Metrics,
+		status:        cfg.Status,
+		logger:        logger,
+		eventBus:      cfg.EventBus,
 	}, nil
 }
 
@@ -288,7 +291,7 @@ func (r *Reconciler) deployStack(ctx context.Context, stack deploy.Stack, commit
 		StackName: stack.Name,
 		Commit:    commitHash,
 		RepoDir:   r.repoDir,
-		Branch:    "", // populated by multi-branch later
+		Branch:    r.resolveStackBranch(stack.Name),
 	}
 	if err := deploy.Deploy(ctx, stack, r.repoDir, r.runner, env); err != nil {
 		r.markStackHealth(ctx, stack.Name, false)
@@ -397,6 +400,18 @@ func (r *Reconciler) deployAll(ctx context.Context) error {
 		return nil // some stacks rolled back but are running
 	}
 	return err
+}
+
+// resolveStackBranch returns the effective branch for a stack.
+// It falls back to the reconciler's defaultBranch if the stack has no
+// explicit branch configured, or if the stack name is not found.
+func (r *Reconciler) resolveStackBranch(stackName string) string {
+	for _, cs := range r.hostStacks {
+		if cs.Name == stackName {
+			return cs.EffectiveBranch(r.defaultBranch)
+		}
+	}
+	return r.defaultBranch
 }
 
 // buildStackPaths returns a map of stack name → path relative to repo root.

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/mohitsharma44/dockcd/internal/config"
 	"github.com/mohitsharma44/dockcd/internal/deploy"
+	"github.com/mohitsharma44/dockcd/internal/hooks"
 	"github.com/mohitsharma44/dockcd/internal/metrics"
 	"github.com/mohitsharma44/dockcd/internal/server"
 )
@@ -274,7 +275,13 @@ func (r *Reconciler) deployGroups(ctx context.Context, groups [][]deploy.Stack, 
 
 // deployStack deploys a single stack, health-checks it, and rolls back on failure.
 func (r *Reconciler) deployStack(ctx context.Context, stack deploy.Stack, commitHash string) error {
-	if err := deploy.Deploy(ctx, stack, r.repoDir, r.runner); err != nil {
+	env := hooks.Env{
+		StackName: stack.Name,
+		Commit:    commitHash,
+		RepoDir:   r.repoDir,
+		Branch:    "", // populated by multi-branch later
+	}
+	if err := deploy.Deploy(ctx, stack, r.repoDir, r.runner, env); err != nil {
 		r.markStackHealth(ctx, stack.Name, false)
 		return err
 	}
@@ -338,8 +345,13 @@ func (r *Reconciler) rollback(ctx context.Context, stack deploy.Stack, currentCo
 	}
 
 	// Deploy from temp dir using a stack with path "." since files are at root.
+	// No hooks on rollback deploys — hooks only run on forward deploys.
 	rollbackStack := deploy.Stack{Name: stack.Name, Path: "."}
-	if err := deploy.Deploy(ctx, rollbackStack, tmpDir, r.runner); err != nil {
+	if err := deploy.Deploy(ctx, rollbackStack, tmpDir, r.runner, hooks.Env{
+		StackName: stack.Name,
+		Commit:    lastGood,
+		RepoDir:   r.repoDir,
+	}); err != nil {
 		r.markStackHealth(ctx, stack.Name, false)
 		r.recordRollbackMetric(ctx, stack.Name, "failure")
 		return fmt.Errorf("rollback deploy failed for %q: %w", stack.Name, err)
@@ -378,6 +390,15 @@ func (r *Reconciler) buildStackPaths() map[string]string {
 	return paths
 }
 
+// configHookToDeployHook converts a config.HookConfig to a hooks.Config.
+// Returns nil if h is nil.
+func configHookToDeployHook(h *config.HookConfig) *hooks.Config {
+	if h == nil {
+		return nil
+	}
+	return &hooks.Config{Command: h.Command, Timeout: h.Timeout}
+}
+
 // filterChangedStacks converts config stacks to deploy stacks, including
 // only those in changedNames. Dependencies not in the changed set are
 // stripped since they're already deployed and running.
@@ -403,12 +424,19 @@ func (r *Reconciler) filterChangedStacks(changedNames []string) []deploy.Stack {
 				deps = append(deps, d)
 			}
 		}
+		var preHook, postHook *hooks.Config
+		if cs.Hooks != nil {
+			preHook = configHookToDeployHook(cs.Hooks.PreDeploy)
+			postHook = configHookToDeployHook(cs.Hooks.PostDeploy)
+		}
 		stacks = append(stacks, deploy.Stack{
 			Name:               cs.Name,
 			Path:               filepath.Join(r.basePath, cs.Path),
 			DependsOn:          deps,
 			HealthCheckTimeout: cs.HealthTimeout(),
 			AutoRollback:       cs.RollbackEnabled(),
+			PreDeployHook:      preHook,
+			PostDeployHook:     postHook,
 		})
 	}
 	return stacks
@@ -418,12 +446,19 @@ func (r *Reconciler) filterChangedStacks(changedNames []string) []deploy.Stack {
 func (r *Reconciler) configToDeployStacks(configStacks []config.Stack) []deploy.Stack {
 	stacks := make([]deploy.Stack, len(configStacks))
 	for i, cs := range configStacks {
+		var preHook, postHook *hooks.Config
+		if cs.Hooks != nil {
+			preHook = configHookToDeployHook(cs.Hooks.PreDeploy)
+			postHook = configHookToDeployHook(cs.Hooks.PostDeploy)
+		}
 		stacks[i] = deploy.Stack{
 			Name:               cs.Name,
 			Path:               filepath.Join(r.basePath, cs.Path),
 			DependsOn:          cs.DependsOn,
 			HealthCheckTimeout: cs.HealthTimeout(),
 			AutoRollback:       cs.RollbackEnabled(),
+			PreDeployHook:      preHook,
+			PostDeployHook:     postHook,
 		}
 	}
 	return stacks

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -35,6 +35,11 @@ type GitPoller interface {
 	LastSuccessfulCommit(stack string) string
 	SetLastSuccessfulCommit(stack, hash string) error
 	ExtractAtCommit(commit, pathPrefix, destDir string) error
+	SuspendStack(name string) error
+	ResumeStack(name string) error
+	IsSuspended(name string) bool
+	NeedsReconcile(name string) bool
+	ClearNeedsReconcile(name string)
 }
 
 // Config holds all dependencies for the Reconciler.
@@ -385,6 +390,10 @@ func (r *Reconciler) filterChangedStacks(changedNames []string) []deploy.Stack {
 	var stacks []deploy.Stack
 	for _, cs := range r.hostStacks {
 		if !changedSet[cs.Name] {
+			continue
+		}
+		if r.poller.IsSuspended(cs.Name) {
+			r.logger.Info("skipping suspended stack", "stack", cs.Name)
 			continue
 		}
 		// Only keep deps that are also being deployed.

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -360,8 +360,9 @@ func (r *Reconciler) rollback(ctx context.Context, stack deploy.Stack, currentCo
 	}
 
 	// Deploy from temp dir using a stack with path "." since files are at root.
-	// No hooks on rollback deploys — hooks only run on forward deploys.
-	rollbackStack := deploy.Stack{Name: stack.Name, Path: "."}
+	// Pre-deploy hooks run again during rollback — the old commit's files
+	// may also need decryption (e.g., SOPS-encrypted .env files).
+	rollbackStack := deploy.Stack{Name: stack.Name, Path: ".", PreDeployHook: stack.PreDeployHook}
 	if err := deploy.Deploy(ctx, rollbackStack, tmpDir, r.runner, hooks.Env{
 		StackName: stack.Name,
 		Commit:    lastGood,
@@ -575,6 +576,10 @@ func (r *Reconciler) TriggerReconcile(ctx context.Context, stackName string) (st
 
 	id := "rec-" + strconv.FormatInt(time.Now().UnixNano(), 10)
 
+	// Use a detached context — the caller's context (HTTP request) will be
+	// cancelled when the handler returns, but the background deploy must continue.
+	bgCtx := context.WithoutCancel(ctx)
+
 	go func() {
 		r.logger.Info("force reconcile triggered", "stack", stackName, "id", id)
 		if _, err := r.poller.Fetch(); err != nil {
@@ -591,7 +596,7 @@ func (r *Reconciler) TriggerReconcile(ctx context.Context, stackName string) (st
 			return
 		}
 		commitHash := r.poller.LastHash()
-		if err := r.deployGroups(ctx, groups, commitHash); err != nil && !errors.Is(err, ErrRolledBack) {
+		if err := r.deployGroups(bgCtx, groups, commitHash); err != nil && !errors.Is(err, ErrRolledBack) {
 			r.logger.Error("force reconcile failed", "error", err)
 		}
 		r.status.Update(time.Now(), commitHash)
@@ -605,13 +610,17 @@ func (r *Reconciler) TriggerReconcile(ctx context.Context, stackName string) (st
 func (r *Reconciler) TriggerReconcileAll(ctx context.Context) (string, error) {
 	id := "rec-" + strconv.FormatInt(time.Now().UnixNano(), 10)
 
+	// Use a detached context — the caller's context (HTTP request) will be
+	// cancelled when the handler returns, but the background deploy must continue.
+	bgCtx := context.WithoutCancel(ctx)
+
 	go func() {
 		r.logger.Info("force reconcile all triggered", "id", id)
 		if _, err := r.poller.Fetch(); err != nil {
 			r.logger.Error("force reconcile fetch failed", "error", err)
 			return
 		}
-		if err := r.deployAll(ctx); err != nil {
+		if err := r.deployAll(bgCtx); err != nil {
 			r.logger.Error("force reconcile deploy failed", "error", err)
 		}
 		r.status.Update(time.Now(), r.poller.LastHash())

--- a/internal/reconciler/reconciler_integration_test.go
+++ b/internal/reconciler/reconciler_integration_test.go
@@ -471,6 +471,359 @@ func TestIntegrationNoHistoryNoRollback(t *testing.T) {
 	}
 }
 
+func TestIntegrationPreDeployHookRuns(t *testing.T) {
+	bareDir := testutil.InitBareRepo(t)
+	workDir := testutil.CloneAndSetup(t, bareDir)
+
+	// Commit both the compose file and a hook script into the stack directory.
+	testutil.CommitFile(t, workDir, "stacks/web/compose.yaml",
+		"services:\n  web:\n    image: nginx", "add web stack")
+	testutil.CommitFile(t, workDir, "stacks/web/hook.sh",
+		"#!/bin/sh\necho hook ran\n", "add hook script")
+
+	cloneDir := filepath.Join(t.TempDir(), "dockcd-clone")
+	poller := git.NewPoller(bareDir, cloneDir)
+	poller.SetStateFile(filepath.Join(cloneDir, ".dockcd_state"))
+
+	var mu sync.Mutex
+	var calls []deployCall
+	runner := func(ctx context.Context, dir, name string, args ...string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, deployCall{dir: dir, name: name, args: args})
+		return nil
+	}
+
+	stacks := []config.Stack{{
+		Name: "web",
+		Path: "stacks/web",
+		Hooks: &config.Hooks{
+			PreDeploy: &config.HookConfig{
+				Command: "sh hook.sh",
+				Timeout: 5 * time.Second,
+			},
+		},
+	}}
+
+	status := &server.Status{}
+	rec, err := New(Config{
+		Poller:       poller,
+		HostStacks:   stacks,
+		Hostname:     "integration-test",
+		RepoDir:      cloneDir,
+		PollInterval: 100 * time.Millisecond,
+		Runner:       runner,
+		Status:       status,
+	})
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	if err := rec.initRepo(); err != nil {
+		t.Fatalf("initRepo failed: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := rec.deployAll(ctx); err != nil {
+		t.Fatalf("deployAll failed (hook should have succeeded): %v", err)
+	}
+
+	// The hook runs via hooks.Run (not the recording runner), so we verify
+	// compose was invoked — meaning the hook succeeded and did not block compose.
+	mu.Lock()
+	n := len(calls)
+	mu.Unlock()
+
+	// 1 stack × 2 commands (pull + up) = 2 calls.
+	if n != 2 {
+		t.Fatalf("expected 2 compose calls (hook ran, compose proceeded), got %d", n)
+	}
+}
+
+func TestIntegrationPreDeployHookFailurePreventsCompose(t *testing.T) {
+	bareDir := testutil.InitBareRepo(t)
+	workDir := testutil.CloneAndSetup(t, bareDir)
+
+	testutil.CommitFile(t, workDir, "stacks/web/compose.yaml",
+		"services:\n  web:\n    image: nginx", "add web stack")
+
+	cloneDir := filepath.Join(t.TempDir(), "dockcd-clone")
+	poller := git.NewPoller(bareDir, cloneDir)
+	poller.SetStateFile(filepath.Join(cloneDir, ".dockcd_state"))
+
+	var mu sync.Mutex
+	var calls []deployCall
+	runner := func(ctx context.Context, dir, name string, args ...string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, deployCall{dir: dir, name: name, args: args})
+		return nil
+	}
+
+	stacks := []config.Stack{{
+		Name: "web",
+		Path: "stacks/web",
+		Hooks: &config.Hooks{
+			PreDeploy: &config.HookConfig{
+				Command: "exit 1",
+				Timeout: 5 * time.Second,
+			},
+		},
+	}}
+
+	status := &server.Status{}
+	rec, err := New(Config{
+		Poller:       poller,
+		HostStacks:   stacks,
+		Hostname:     "integration-test",
+		RepoDir:      cloneDir,
+		PollInterval: 100 * time.Millisecond,
+		Runner:       runner,
+		Status:       status,
+	})
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	if err := rec.initRepo(); err != nil {
+		t.Fatalf("initRepo failed: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := rec.deployAll(ctx); err == nil {
+		t.Fatal("expected deployAll to return error when pre-deploy hook fails")
+	}
+
+	// Hook failed — compose must never have been called.
+	mu.Lock()
+	n := len(calls)
+	mu.Unlock()
+
+	if n != 0 {
+		t.Fatalf("expected 0 compose calls when hook fails, got %d", n)
+	}
+}
+
+func TestIntegrationSuspendSkipsStack(t *testing.T) {
+	bareDir := testutil.InitBareRepo(t)
+	workDir := testutil.CloneAndSetup(t, bareDir)
+	testutil.CommitFile(t, workDir, "stacks/web/compose.yaml",
+		"services:\n  web:\n    image: nginx", "add web stack")
+
+	cloneDir := filepath.Join(t.TempDir(), "dockcd-clone")
+	poller := git.NewPoller(bareDir, cloneDir)
+	poller.SetStateFile(filepath.Join(cloneDir, ".dockcd_state"))
+
+	var mu sync.Mutex
+	var calls []deployCall
+	runner := func(ctx context.Context, dir, name string, args ...string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, deployCall{dir: dir, name: name, args: args})
+		return nil
+	}
+
+	status := &server.Status{}
+	rec, err := New(Config{
+		Poller:       poller,
+		HostStacks:   []config.Stack{{Name: "web", Path: "stacks/web"}},
+		Hostname:     "integration-test",
+		RepoDir:      cloneDir,
+		PollInterval: 100 * time.Millisecond,
+		Runner:       runner,
+		Status:       status,
+	})
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	if err := rec.initRepo(); err != nil {
+		t.Fatalf("initRepo failed: %v", err)
+	}
+
+	// Suspend the stack before any reconcile.
+	if err := poller.SuspendStack("web"); err != nil {
+		t.Fatalf("SuspendStack failed: %v", err)
+	}
+
+	// Push a change so reconcile sees a diff.
+	testutil.CommitFile(t, workDir, "stacks/web/compose.yaml",
+		"services:\n  web:\n    image: nginx:alpine", "update web stack")
+
+	ctx := context.Background()
+	if err := rec.reconcile(ctx); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	// Stack is suspended — no compose calls expected.
+	mu.Lock()
+	n := len(calls)
+	mu.Unlock()
+
+	if n != 0 {
+		t.Fatalf("expected 0 compose calls for suspended stack, got %d", n)
+	}
+}
+
+func TestIntegrationResumeDeploysStack(t *testing.T) {
+	bareDir := testutil.InitBareRepo(t)
+	workDir := testutil.CloneAndSetup(t, bareDir)
+	testutil.CommitFile(t, workDir, "stacks/web/compose.yaml",
+		"services:\n  web:\n    image: nginx", "add web stack")
+
+	cloneDir := filepath.Join(t.TempDir(), "dockcd-clone")
+	poller := git.NewPoller(bareDir, cloneDir)
+	poller.SetStateFile(filepath.Join(cloneDir, ".dockcd_state"))
+
+	var mu sync.Mutex
+	var calls []deployCall
+	runner := func(ctx context.Context, dir, name string, args ...string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, deployCall{dir: dir, name: name, args: args})
+		return nil
+	}
+
+	status := &server.Status{}
+	rec, err := New(Config{
+		Poller:       poller,
+		HostStacks:   []config.Stack{{Name: "web", Path: "stacks/web"}},
+		Hostname:     "integration-test",
+		RepoDir:      cloneDir,
+		PollInterval: 100 * time.Millisecond,
+		Runner:       runner,
+		Status:       status,
+	})
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	if err := rec.initRepo(); err != nil {
+		t.Fatalf("initRepo failed: %v", err)
+	}
+
+	// Suspend the stack before any reconcile.
+	if err := poller.SuspendStack("web"); err != nil {
+		t.Fatalf("SuspendStack failed: %v", err)
+	}
+
+	// Push a change while suspended.
+	testutil.CommitFile(t, workDir, "stacks/web/compose.yaml",
+		"services:\n  web:\n    image: nginx:alpine", "update web stack")
+
+	ctx := context.Background()
+
+	// First reconcile — stack is suspended, should skip.
+	if err := rec.reconcile(ctx); err != nil {
+		t.Fatalf("reconcile (suspended) failed: %v", err)
+	}
+
+	mu.Lock()
+	nAfterSuspend := len(calls)
+	mu.Unlock()
+
+	if nAfterSuspend != 0 {
+		t.Fatalf("expected 0 compose calls while suspended, got %d", nAfterSuspend)
+	}
+
+	// Resume the stack.
+	if err := poller.ResumeStack("web"); err != nil {
+		t.Fatalf("ResumeStack failed: %v", err)
+	}
+
+	// Second reconcile — the previously-fetched change is already the current
+	// tip, so we push another commit to ensure reconcile detects a diff.
+	testutil.CommitFile(t, workDir, "stacks/web/compose.yaml",
+		"services:\n  web:\n    image: nginx:latest", "post-resume update")
+
+	if err := rec.reconcile(ctx); err != nil {
+		t.Fatalf("reconcile (after resume) failed: %v", err)
+	}
+
+	mu.Lock()
+	nAfterResume := len(calls)
+	mu.Unlock()
+
+	// 1 stack × 2 commands (pull + up) = 2 calls.
+	if nAfterResume != 2 {
+		t.Fatalf("expected 2 compose calls after resume, got %d", nAfterResume)
+	}
+}
+
+func TestIntegrationTriggerReconcile(t *testing.T) {
+	bareDir := testutil.InitBareRepo(t)
+	workDir := testutil.CloneAndSetup(t, bareDir)
+	testutil.CommitFile(t, workDir, "stacks/web/compose.yaml",
+		"services:\n  web:\n    image: nginx", "add web stack")
+
+	cloneDir := filepath.Join(t.TempDir(), "dockcd-clone")
+	poller := git.NewPoller(bareDir, cloneDir)
+	poller.SetStateFile(filepath.Join(cloneDir, ".dockcd_state"))
+
+	// Use a channel to signal when the async deploy has finished.
+	done := make(chan struct{})
+	var mu sync.Mutex
+	var calls []deployCall
+	runner := func(ctx context.Context, dir, name string, args ...string) error {
+		mu.Lock()
+		calls = append(calls, deployCall{dir: dir, name: name, args: args})
+		n := len(calls)
+		mu.Unlock()
+		// 1 stack × 2 commands (pull + up) = 2 calls.
+		if n >= 2 {
+			select {
+			case <-done: // already closed
+			default:
+				close(done)
+			}
+		}
+		return nil
+	}
+
+	status := &server.Status{}
+	rec, err := New(Config{
+		Poller:       poller,
+		HostStacks:   []config.Stack{{Name: "web", Path: "stacks/web"}},
+		Hostname:     "integration-test",
+		RepoDir:      cloneDir,
+		PollInterval: 100 * time.Millisecond,
+		Runner:       runner,
+		Status:       status,
+	})
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	if err := rec.initRepo(); err != nil {
+		t.Fatalf("initRepo failed: %v", err)
+	}
+
+	ctx := context.Background()
+	id, err := rec.TriggerReconcile(ctx, "web")
+	if err != nil {
+		t.Fatalf("TriggerReconcile failed: %v", err)
+	}
+	if id == "" {
+		t.Fatal("expected non-empty reconcile ID")
+	}
+
+	// Wait for the async goroutine to finish, with a generous timeout.
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("TriggerReconcile goroutine did not complete in time")
+	}
+
+	mu.Lock()
+	n := len(calls)
+	mu.Unlock()
+
+	// Expect pull + up = 2 calls.
+	if n != 2 {
+		t.Fatalf("expected 2 compose calls from TriggerReconcile, got %d", n)
+	}
+}
+
 func TestIntegrationStateFileMigration(t *testing.T) {
 	bareDir := testutil.InitBareRepo(t)
 	workDir := testutil.CloneAndSetup(t, bareDir)

--- a/internal/reconciler/reconciler_integration_test.go
+++ b/internal/reconciler/reconciler_integration_test.go
@@ -824,6 +824,80 @@ func TestIntegrationTriggerReconcile(t *testing.T) {
 	}
 }
 
+func TestIntegrationBranchPassedToHookEnv(t *testing.T) {
+	bareDir := testutil.InitBareRepo(t)
+	workDir := testutil.CloneAndSetup(t, bareDir)
+
+	// Use t.Name() in the temp file path to avoid collisions with parallel tests.
+	tmpFile := "/tmp/dockcd-test-branch-" + strings.ReplaceAll(t.Name(), "/", "_")
+	defer os.Remove(tmpFile)
+
+	// Commit compose file and a hook script that writes $DOCKCD_BRANCH to a temp file.
+	testutil.CommitFile(t, workDir, "stacks/web/compose.yaml",
+		"services:\n  web:\n    image: nginx", "add web stack")
+	testutil.CommitFile(t, workDir, "stacks/web/branch-hook.sh",
+		"#!/bin/sh\necho $DOCKCD_BRANCH > "+tmpFile+"\n", "add branch hook")
+
+	cloneDir := filepath.Join(t.TempDir(), "dockcd-clone")
+	poller := git.NewPoller(bareDir, cloneDir)
+	poller.SetStateFile(filepath.Join(cloneDir, ".dockcd_state"))
+
+	var mu sync.Mutex
+	var calls []deployCall
+	runner := func(ctx context.Context, dir, name string, args ...string) error {
+		mu.Lock()
+		defer mu.Unlock()
+		calls = append(calls, deployCall{dir: dir, name: name, args: args})
+		return nil
+	}
+
+	stacks := []config.Stack{{
+		Name:   "web",
+		Path:   "stacks/web",
+		Branch: "main",
+		Hooks: &config.Hooks{
+			PreDeploy: &config.HookConfig{
+				Command: "sh branch-hook.sh",
+				Timeout: 5 * time.Second,
+			},
+		},
+	}}
+
+	status := &server.Status{}
+	rec, err := New(Config{
+		Poller:        poller,
+		HostStacks:    stacks,
+		Hostname:      "integration-test",
+		RepoDir:       cloneDir,
+		DefaultBranch: "main",
+		PollInterval:  100 * time.Millisecond,
+		Runner:        runner,
+		Status:        status,
+	})
+	if err != nil {
+		t.Fatalf("New() failed: %v", err)
+	}
+
+	if err := rec.initRepo(); err != nil {
+		t.Fatalf("initRepo failed: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := rec.deployAll(ctx); err != nil {
+		t.Fatalf("deployAll failed: %v", err)
+	}
+
+	// Read the temp file written by the hook and verify it contains "main".
+	data, err := os.ReadFile(tmpFile)
+	if err != nil {
+		t.Fatalf("hook did not write temp file %q: %v", tmpFile, err)
+	}
+	got := strings.TrimSpace(string(data))
+	if got != "main" {
+		t.Errorf("expected DOCKCD_BRANCH=%q, hook wrote %q", "main", got)
+	}
+}
+
 func TestIntegrationStateFileMigration(t *testing.T) {
 	bareDir := testutil.InitBareRepo(t)
 	workDir := testutil.CloneAndSetup(t, bareDir)

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -35,6 +35,8 @@ type mockPoller struct {
 	extractedFiles       map[string]string // path -> content (for rollback tests)
 	mu                   sync.Mutex
 	setSuccessfulCalled  map[string]string // stack -> hash
+	suspendedStacks      map[string]bool
+	needsReconcileSet    map[string]bool
 }
 
 func (m *mockPoller) Clone() error {
@@ -96,6 +98,49 @@ func (m *mockPoller) ExtractAtCommit(commit, pathPrefix, destDir string) error {
 		}
 	}
 	return nil
+}
+
+func (m *mockPoller) SuspendStack(name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.suspendedStacks == nil {
+		m.suspendedStacks = make(map[string]bool)
+	}
+	m.suspendedStacks[name] = true
+	return nil
+}
+
+func (m *mockPoller) ResumeStack(name string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.suspendedStacks != nil {
+		delete(m.suspendedStacks, name)
+	}
+	if m.needsReconcileSet == nil {
+		m.needsReconcileSet = make(map[string]bool)
+	}
+	m.needsReconcileSet[name] = true
+	return nil
+}
+
+func (m *mockPoller) IsSuspended(name string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.suspendedStacks[name]
+}
+
+func (m *mockPoller) NeedsReconcile(name string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.needsReconcileSet[name]
+}
+
+func (m *mockPoller) ClearNeedsReconcile(name string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.needsReconcileSet != nil {
+		delete(m.needsReconcileSet, name)
+	}
 }
 
 // --- Mock CommandRunner ---
@@ -730,5 +775,43 @@ func TestDeployStackDeployFailureNoRollback(t *testing.T) {
 	// Should NOT have attempted rollback (deploy itself failed).
 	if _, ok := poller.setSuccessfulCalled["web"]; ok {
 		t.Error("should not update successful commit after deploy failure")
+	}
+}
+
+func TestReconcileSkipsSuspendedStack(t *testing.T) {
+	stacks := []config.Stack{
+		{Name: "traefik", Path: "server04/traefik"},
+		{Name: "vault", Path: "server04/vault"},
+	}
+
+	poller := &mockPoller{
+		fetchChanged:  true,
+		lastHash:      "def456",
+		changedStacks: []string{"traefik", "vault"},
+		// vault is suspended
+		suspendedStacks: map[string]bool{"vault": true},
+	}
+
+	var mu sync.Mutex
+	var calls []deployCall
+	r, _ := testReconciler(t, poller, stacks, mockRunner(&mu, &calls))
+
+	if err := r.reconcile(context.Background()); err != nil {
+		t.Fatalf("reconcile failed: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Only traefik should be deployed: 2 calls (pull + up).
+	// vault is suspended and must be skipped.
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 deploy calls (traefik only), got %d: %+v", len(calls), calls)
+	}
+
+	for _, c := range calls {
+		if c.dir != "/opt/repo/docker/stacks/server04/traefik" {
+			t.Errorf("unexpected deploy dir %q: expected only traefik", c.dir)
+		}
 	}
 }

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -8,12 +8,14 @@ import (
 	"path/filepath"
 	"slices"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/mohitsharma44/dockcd/internal/config"
 	"github.com/mohitsharma44/dockcd/internal/deploy"
+	"github.com/mohitsharma44/dockcd/internal/notify"
 	"github.com/mohitsharma44/dockcd/internal/server"
 )
 
@@ -814,4 +816,67 @@ func TestReconcileSkipsSuspendedStack(t *testing.T) {
 			t.Errorf("unexpected deploy dir %q: expected only traefik", c.dir)
 		}
 	}
+}
+
+// --- TriggerReconcile / TriggerReconcileAll tests ---
+
+func TestTriggerReconcileNonExistentStack(t *testing.T) {
+	poller := &mockPoller{lastHash: "abc123"}
+	r, _ := testReconciler(t, poller, []config.Stack{{Name: "web", Path: "web"}}, nil)
+	_, err := r.TriggerReconcile(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent stack")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' error, got: %v", err)
+	}
+}
+
+func TestTriggerReconcileSuspendedStack(t *testing.T) {
+	poller := &mockPoller{
+		lastHash:        "abc123",
+		suspendedStacks: map[string]bool{"web": true},
+	}
+	r, _ := testReconciler(t, poller, []config.Stack{{Name: "web", Path: "web"}}, nil)
+	_, err := r.TriggerReconcile(context.Background(), "web")
+	if err == nil {
+		t.Fatal("expected error for suspended stack")
+	}
+	if !strings.Contains(err.Error(), "suspended") {
+		t.Errorf("expected 'suspended' error, got: %v", err)
+	}
+}
+
+func TestTriggerReconcileReturnsID(t *testing.T) {
+	poller := &mockPoller{lastHash: "abc123"}
+	r, _ := testReconciler(t, poller, []config.Stack{{Name: "web", Path: "web"}}, nil)
+	id, err := r.TriggerReconcile(context.Background(), "web")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id == "" {
+		t.Error("expected non-empty ID")
+	}
+	if !strings.HasPrefix(id, "rec-") {
+		t.Errorf("expected 'rec-' prefix, got %q", id)
+	}
+}
+
+func TestTriggerReconcileAllReturnsID(t *testing.T) {
+	poller := &mockPoller{lastHash: "abc123"}
+	r, _ := testReconciler(t, poller, []config.Stack{{Name: "web", Path: "web"}}, nil)
+	id, err := r.TriggerReconcileAll(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(id, "rec-") {
+		t.Errorf("expected 'rec-' prefix, got %q", id)
+	}
+}
+
+func TestEmitNilEventBus(t *testing.T) {
+	poller := &mockPoller{lastHash: "abc123"}
+	r, _ := testReconciler(t, poller, nil, nil)
+	// Should not panic with nil eventBus.
+	r.emit(notify.EventDeploySuccess, "web", "abc", "ok")
 }

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -880,3 +880,24 @@ func TestEmitNilEventBus(t *testing.T) {
 	// Should not panic with nil eventBus.
 	r.emit(notify.EventDeploySuccess, "web", "abc", "ok")
 }
+
+func TestResolveStackBranch(t *testing.T) {
+	stacks := []config.Stack{
+		{Name: "traefik", Path: "p/traefik", Branch: "canary"},
+		{Name: "vault", Path: "p/vault"},
+	}
+
+	poller := &mockPoller{lastHash: "abc123"}
+	r, _ := testReconciler(t, poller, stacks, nil)
+	r.defaultBranch = "main"
+
+	if got := r.resolveStackBranch("traefik"); got != "canary" {
+		t.Errorf("expected 'canary', got %q", got)
+	}
+	if got := r.resolveStackBranch("vault"); got != "main" {
+		t.Errorf("expected 'main', got %q", got)
+	}
+	if got := r.resolveStackBranch("nonexistent"); got != "main" {
+		t.Errorf("expected 'main' for unknown stack, got %q", got)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,18 +5,51 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
+	"runtime"
 	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/mohitsharma44/dockcd/internal/notify"
 )
 
-// Status holds shared state for the healthz endpoint.
+// Version is the server version string. Set by the caller (e.g. main) before
+// calling New. Defaults to "dev".
+var Version = "dev"
+
+// StackState tracks the runtime state of a single stack.
+type StackState struct {
+	Name       string    `json:"name"`
+	Host       string    `json:"host"`
+	Branch     string    `json:"branch"`
+	Status     string    `json:"status"` // Ready, Failed, Suspended, Reconciling
+	Health     string    `json:"health"` // Healthy, Degraded, Unknown
+	LastDeploy time.Time `json:"last_deploy"`
+	Commit     string    `json:"commit"`
+	Suspended  bool      `json:"suspended"`
+}
+
+// ReconcileTriggerer triggers async reconciliation.
+type ReconcileTriggerer interface {
+	TriggerReconcile(ctx context.Context, stackName string) (string, error)
+	TriggerReconcileAll(ctx context.Context) (string, error)
+}
+
+// Suspender manages stack suspension state.
+type Suspender interface {
+	SuspendStack(name string) error
+	ResumeStack(name string) error
+	IsSuspended(name string) bool
+}
+
+// Status holds shared state for the healthz endpoint and stack tracking.
 // It is safe for concurrent reads and writes (protected by RWMutex).
 type Status struct {
 	mu       sync.RWMutex
 	lastSync time.Time
 	commit   string
+	stacks   map[string]*StackState
 }
 
 // Update sets the last sync time and current commit.
@@ -42,18 +75,64 @@ func (s *Status) Snapshot() (time.Time, string) {
 	return s.lastSync, s.commit
 }
 
+// UpdateStack creates or replaces the state for the named stack.
+func (s *Status) UpdateStack(name string, state *StackState) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.stacks == nil {
+		s.stacks = make(map[string]*StackState)
+	}
+	s.stacks[name] = state
+}
+
+// GetStacks returns a snapshot of all tracked stacks. Never returns nil.
+func (s *Status) GetStacks() []StackState {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	result := make([]StackState, 0, len(s.stacks))
+	for _, st := range s.stacks {
+		result = append(result, *st)
+	}
+	return result
+}
+
+// GetStack returns a copy of the named stack's state, or nil if not found.
+func (s *Status) GetStack(name string) *StackState {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if st, ok := s.stacks[name]; ok {
+		cp := *st
+		return &cp
+	}
+	return nil
+}
+
 // Server wraps an http.Server with dockcd-specific routes.
 type Server struct {
 	httpServer *http.Server
 	status     *Status
 	logger     *slog.Logger
+	suspender  Suspender
+	triggerer  ReconcileTriggerer
+	eventBus   *notify.EventBus
 }
 
 // New creates a Server listening on the given address (e.g. ":9092").
-// It registers:
-//   - GET /metrics  — Prometheus metrics (served by OTel Prometheus exporter)
-//   - GET /healthz  — JSON health check with last sync time and commit
-func New(addr string, status *Status, logger *slog.Logger) *Server {
+// suspender, triggerer, and eventBus are optional; pass nil to disable those
+// features (affected endpoints return 501 Not Implemented).
+//
+// Registered routes:
+//
+//	GET  /metrics                      — Prometheus metrics
+//	GET  /healthz                      — JSON health check
+//	GET  /api/v1/stacks                — list all stacks
+//	GET  /api/v1/stacks/{name}         — get single stack
+//	POST /api/v1/stacks/{name}/suspend — suspend a stack
+//	POST /api/v1/stacks/{name}/resume  — resume a stack
+//	POST /api/v1/reconcile             — trigger reconcile for all stacks
+//	POST /api/v1/reconcile/{name}      — trigger reconcile for one stack
+//	GET  /api/v1/version               — server version info
+func New(addr string, status *Status, logger *slog.Logger, suspender Suspender, triggerer ReconcileTriggerer, eventBus *notify.EventBus) *Server {
 	if status == nil {
 		status = &Status{}
 	}
@@ -70,12 +149,23 @@ func New(addr string, status *Status, logger *slog.Logger) *Server {
 			ReadHeaderTimeout: 10 * time.Second,
 			IdleTimeout:       60 * time.Second,
 		},
-		status: status,
-		logger: logger,
+		status:    status,
+		logger:    logger,
+		suspender: suspender,
+		triggerer: triggerer,
+		eventBus:  eventBus,
 	}
 
 	mux.Handle("GET /metrics", promhttp.Handler())
 	mux.HandleFunc("GET /healthz", s.handleHealthz)
+
+	mux.HandleFunc("GET /api/v1/stacks", s.handleGetStacks)
+	mux.HandleFunc("GET /api/v1/stacks/{name}", s.handleGetStack)
+	mux.HandleFunc("POST /api/v1/stacks/{name}/suspend", s.handleSuspend)
+	mux.HandleFunc("POST /api/v1/stacks/{name}/resume", s.handleResume)
+	mux.HandleFunc("POST /api/v1/reconcile", s.handleReconcileAll)
+	mux.HandleFunc("POST /api/v1/reconcile/{name}", s.handleReconcile)
+	mux.HandleFunc("GET /api/v1/version", s.handleVersion)
 
 	return s
 }
@@ -107,5 +197,139 @@ func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		s.logger.Error("failed to encode /healthz response", "error", err)
+	}
+}
+
+// handleGetStacks returns all tracked stacks as a JSON array.
+func (s *Server) handleGetStacks(w http.ResponseWriter, r *http.Request) {
+	stacks := s.status.GetStacks()
+	if stacks == nil {
+		stacks = []StackState{}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string][]StackState{"stacks": stacks}); err != nil {
+		s.logger.Error("failed to encode /api/v1/stacks response", "error", err)
+	}
+}
+
+// handleGetStack returns a single stack by name.
+func (s *Server) handleGetStack(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	stack := s.status.GetStack(name)
+	if stack == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "stack not found: " + name})
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(stack); err != nil {
+		s.logger.Error("failed to encode stack response", "error", err, "stack", name)
+	}
+}
+
+// handleSuspend suspends the named stack.
+func (s *Server) handleSuspend(w http.ResponseWriter, r *http.Request) {
+	if s.suspender == nil {
+		http.Error(w, "suspend not available", http.StatusNotImplemented)
+		return
+	}
+	name := r.PathValue("name")
+	stack := s.status.GetStack(name)
+	if stack == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "stack not found: " + name})
+		return
+	}
+	if err := s.suspender.SuspendStack(name); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	stack.Suspended = true
+	stack.Status = "Suspended"
+	s.status.UpdateStack(name, stack)
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(stack); err != nil {
+		s.logger.Error("failed to encode suspend response", "error", err, "stack", name)
+	}
+}
+
+// handleResume resumes the named stack.
+func (s *Server) handleResume(w http.ResponseWriter, r *http.Request) {
+	if s.suspender == nil {
+		http.Error(w, "resume not available", http.StatusNotImplemented)
+		return
+	}
+	name := r.PathValue("name")
+	stack := s.status.GetStack(name)
+	if stack == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "stack not found: " + name})
+		return
+	}
+	if err := s.suspender.ResumeStack(name); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	stack.Suspended = false
+	stack.Status = "Ready"
+	s.status.UpdateStack(name, stack)
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(stack); err != nil {
+		s.logger.Error("failed to encode resume response", "error", err, "stack", name)
+	}
+}
+
+// handleReconcileAll triggers reconciliation for all stacks.
+func (s *Server) handleReconcileAll(w http.ResponseWriter, r *http.Request) {
+	if s.triggerer == nil {
+		http.Error(w, "reconcile not available", http.StatusNotImplemented)
+		return
+	}
+	id, err := s.triggerer.TriggerReconcileAll(r.Context())
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	if err := json.NewEncoder(w).Encode(map[string]string{"id": id, "status": "queued"}); err != nil {
+		s.logger.Error("failed to encode reconcile-all response", "error", err)
+	}
+}
+
+// handleReconcile triggers reconciliation for a single named stack.
+func (s *Server) handleReconcile(w http.ResponseWriter, r *http.Request) {
+	if s.triggerer == nil {
+		http.Error(w, "reconcile not available", http.StatusNotImplemented)
+		return
+	}
+	name := r.PathValue("name")
+	id, err := s.triggerer.TriggerReconcile(r.Context(), name)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	if err := json.NewEncoder(w).Encode(map[string]string{"id": id, "status": "queued", "stack": name}); err != nil {
+		s.logger.Error("failed to encode reconcile response", "error", err, "stack", name)
+	}
+}
+
+// handleVersion returns the server and Go runtime version.
+func (s *Server) handleVersion(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]string{
+		"server": Version,
+		"go":     runtime.Version(),
+	}); err != nil {
+		s.logger.Error("failed to encode version response", "error", err)
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,19 +1,97 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
 
+// --- mock implementations ---
+
+type mockSuspender struct {
+	suspended map[string]bool
+	err       error // if non-nil, SuspendStack/ResumeStack returns this
+}
+
+func newMockSuspender() *mockSuspender {
+	return &mockSuspender{suspended: make(map[string]bool)}
+}
+
+func (m *mockSuspender) SuspendStack(name string) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.suspended[name] = true
+	return nil
+}
+
+func (m *mockSuspender) ResumeStack(name string) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.suspended[name] = false
+	return nil
+}
+
+func (m *mockSuspender) IsSuspended(name string) bool {
+	return m.suspended[name]
+}
+
+type mockTriggerer struct {
+	lastID      string
+	knownStacks map[string]bool // if set, TriggerReconcile errors on unknown stacks
+	err         error
+}
+
+func newMockTriggerer(id string) *mockTriggerer {
+	return &mockTriggerer{lastID: id}
+}
+
+func (m *mockTriggerer) TriggerReconcile(ctx context.Context, stackName string) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	if m.knownStacks != nil && !m.knownStacks[stackName] {
+		return "", &stackNotFoundError{name: stackName}
+	}
+	return m.lastID, nil
+}
+
+func (m *mockTriggerer) TriggerReconcileAll(ctx context.Context) (string, error) {
+	if m.err != nil {
+		return "", m.err
+	}
+	return m.lastID, nil
+}
+
+// stackNotFoundError is a simple error type returned by the mock triggerer.
+type stackNotFoundError struct{ name string }
+
+func (e *stackNotFoundError) Error() string { return "stack not found: " + e.name }
+
+// --- helpers ---
+
+func newTestServer(status *Status, suspender Suspender, triggerer ReconcileTriggerer) *Server {
+	return New(":0", status, nil, suspender, triggerer, nil)
+}
+
+func do(srv *Server, method, path string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, path, nil)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+	return rec
+}
+
+// --- existing healthz tests (updated signature) ---
+
 func TestHealthzReturnsOK(t *testing.T) {
 	status := &Status{}
-	srv := New(":0", status, nil)
+	srv := New(":0", status, nil, nil, nil, nil)
 
-	// httptest.NewRequest creates a fake request (no real network).
-	// httptest.NewRecorder captures the response like flask.test_client().
 	req := httptest.NewRequest("GET", "/healthz", nil)
 	rec := httptest.NewRecorder()
 
@@ -41,9 +119,8 @@ func TestHealthzReturnsOK(t *testing.T) {
 
 func TestHealthzReflectsStatusUpdate(t *testing.T) {
 	status := &Status{}
-	srv := New(":0", status, nil)
+	srv := New(":0", status, nil, nil, nil, nil)
 
-	// Simulate a successful deploy updating the status.
 	syncTime := time.Date(2026, 3, 12, 10, 0, 0, 0, time.UTC)
 	status.Update(syncTime, "abc1234")
 
@@ -67,7 +144,7 @@ func TestHealthzReflectsStatusUpdate(t *testing.T) {
 
 func TestHealthzContentType(t *testing.T) {
 	status := &Status{}
-	srv := New(":0", status, nil)
+	srv := New(":0", status, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("GET", "/healthz", nil)
 	rec := httptest.NewRecorder()
@@ -82,7 +159,7 @@ func TestHealthzContentType(t *testing.T) {
 
 func TestMetricsEndpointResponds(t *testing.T) {
 	status := &Status{}
-	srv := New(":0", status, nil)
+	srv := New(":0", status, nil, nil, nil, nil)
 
 	req := httptest.NewRequest("GET", "/metrics", nil)
 	rec := httptest.NewRecorder()
@@ -93,9 +170,393 @@ func TestMetricsEndpointResponds(t *testing.T) {
 		t.Fatalf("expected status 200, got %d", rec.Code)
 	}
 
-	// Prometheus metrics endpoint should return text content.
 	body := rec.Body.String()
 	if len(body) == 0 {
 		t.Error("expected non-empty metrics response")
+	}
+}
+
+// --- stack API tests ---
+
+func TestGetStacksEmpty(t *testing.T) {
+	srv := newTestServer(&Status{}, nil, nil)
+	rec := do(srv, "GET", "/api/v1/stacks")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var body map[string][]StackState
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	stacks, ok := body["stacks"]
+	if !ok {
+		t.Fatal("expected 'stacks' key in response")
+	}
+	if len(stacks) != 0 {
+		t.Errorf("expected empty stacks array, got %d items", len(stacks))
+	}
+	// Ensure it encodes as [] not null.
+	raw := rec.Body.String()
+	if strings.Contains(raw, "null") {
+		t.Errorf("stacks should be [] not null, got: %s", raw)
+	}
+}
+
+func TestGetStacksWithData(t *testing.T) {
+	status := &Status{}
+	status.UpdateStack("web", &StackState{
+		Name:   "web",
+		Host:   "host1",
+		Branch: "main",
+		Status: "Ready",
+		Health: "Healthy",
+	})
+	status.UpdateStack("api", &StackState{
+		Name:   "api",
+		Host:   "host1",
+		Branch: "main",
+		Status: "Ready",
+		Health: "Healthy",
+	})
+
+	srv := newTestServer(status, nil, nil)
+	rec := do(srv, "GET", "/api/v1/stacks")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var body map[string][]StackState
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	if len(body["stacks"]) != 2 {
+		t.Errorf("expected 2 stacks, got %d", len(body["stacks"]))
+	}
+}
+
+func TestGetStacksContentType(t *testing.T) {
+	srv := newTestServer(&Status{}, nil, nil)
+	rec := do(srv, "GET", "/api/v1/stacks")
+
+	ct := rec.Header().Get("Content-Type")
+	if ct != "application/json" {
+		t.Errorf("expected application/json, got %q", ct)
+	}
+}
+
+func TestGetStackNotFound(t *testing.T) {
+	srv := newTestServer(&Status{}, nil, nil)
+	rec := do(srv, "GET", "/api/v1/stacks/nonexistent")
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	if !strings.Contains(body["error"], "nonexistent") {
+		t.Errorf("expected error to mention stack name, got %q", body["error"])
+	}
+}
+
+func TestGetStackFound(t *testing.T) {
+	status := &Status{}
+	status.UpdateStack("web", &StackState{
+		Name:   "web",
+		Host:   "host1",
+		Branch: "main",
+		Status: "Ready",
+		Health: "Healthy",
+		Commit: "deadbeef",
+	})
+
+	srv := newTestServer(status, nil, nil)
+	rec := do(srv, "GET", "/api/v1/stacks/web")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var stack StackState
+	if err := json.NewDecoder(rec.Body).Decode(&stack); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	if stack.Name != "web" {
+		t.Errorf("expected name 'web', got %q", stack.Name)
+	}
+	if stack.Commit != "deadbeef" {
+		t.Errorf("expected commit 'deadbeef', got %q", stack.Commit)
+	}
+	if stack.Status != "Ready" {
+		t.Errorf("expected status 'Ready', got %q", stack.Status)
+	}
+}
+
+func TestSuspendStack(t *testing.T) {
+	status := &Status{}
+	status.UpdateStack("web", &StackState{
+		Name:   "web",
+		Status: "Ready",
+	})
+
+	suspender := newMockSuspender()
+	srv := newTestServer(status, suspender, nil)
+	rec := do(srv, "POST", "/api/v1/stacks/web/suspend")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var stack StackState
+	if err := json.NewDecoder(rec.Body).Decode(&stack); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	if !stack.Suspended {
+		t.Error("expected Suspended=true")
+	}
+	if stack.Status != "Suspended" {
+		t.Errorf("expected status 'Suspended', got %q", stack.Status)
+	}
+
+	// Verify persisted in status.
+	persisted := status.GetStack("web")
+	if persisted == nil || !persisted.Suspended {
+		t.Error("expected status to persist Suspended=true")
+	}
+}
+
+func TestResumeStack(t *testing.T) {
+	status := &Status{}
+	status.UpdateStack("web", &StackState{
+		Name:      "web",
+		Status:    "Suspended",
+		Suspended: true,
+	})
+
+	suspender := newMockSuspender()
+	suspender.suspended["web"] = true
+	srv := newTestServer(status, suspender, nil)
+	rec := do(srv, "POST", "/api/v1/stacks/web/resume")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var stack StackState
+	if err := json.NewDecoder(rec.Body).Decode(&stack); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	if stack.Suspended {
+		t.Error("expected Suspended=false after resume")
+	}
+	if stack.Status != "Ready" {
+		t.Errorf("expected status 'Ready', got %q", stack.Status)
+	}
+
+	persisted := status.GetStack("web")
+	if persisted == nil || persisted.Suspended {
+		t.Error("expected status to persist Suspended=false")
+	}
+}
+
+func TestSuspendNotFound(t *testing.T) {
+	suspender := newMockSuspender()
+	srv := newTestServer(&Status{}, suspender, nil)
+	rec := do(srv, "POST", "/api/v1/stacks/ghost/suspend")
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if !strings.Contains(body["error"], "ghost") {
+		t.Errorf("expected error to mention stack name, got %q", body["error"])
+	}
+}
+
+func TestResumeNotFound(t *testing.T) {
+	suspender := newMockSuspender()
+	srv := newTestServer(&Status{}, suspender, nil)
+	rec := do(srv, "POST", "/api/v1/stacks/ghost/resume")
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+func TestSuspendNilSuspender(t *testing.T) {
+	status := &Status{}
+	status.UpdateStack("web", &StackState{Name: "web"})
+	srv := newTestServer(status, nil, nil)
+	rec := do(srv, "POST", "/api/v1/stacks/web/suspend")
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("expected 501, got %d", rec.Code)
+	}
+}
+
+func TestResumeNilSuspender(t *testing.T) {
+	status := &Status{}
+	status.UpdateStack("web", &StackState{Name: "web"})
+	srv := newTestServer(status, nil, nil)
+	rec := do(srv, "POST", "/api/v1/stacks/web/resume")
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("expected 501, got %d", rec.Code)
+	}
+}
+
+func TestReconcileStack(t *testing.T) {
+	status := &Status{}
+	status.UpdateStack("web", &StackState{Name: "web"})
+
+	triggerer := newMockTriggerer("rec-123")
+	srv := newTestServer(status, nil, triggerer)
+	rec := do(srv, "POST", "/api/v1/reconcile/web")
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", rec.Code)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	if body["id"] != "rec-123" {
+		t.Errorf("expected id 'rec-123', got %q", body["id"])
+	}
+	if body["status"] != "queued" {
+		t.Errorf("expected status 'queued', got %q", body["status"])
+	}
+	if body["stack"] != "web" {
+		t.Errorf("expected stack 'web', got %q", body["stack"])
+	}
+}
+
+func TestReconcileAll(t *testing.T) {
+	triggerer := newMockTriggerer("rec-all-456")
+	srv := newTestServer(&Status{}, nil, triggerer)
+	rec := do(srv, "POST", "/api/v1/reconcile")
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d", rec.Code)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	if body["id"] != "rec-all-456" {
+		t.Errorf("expected id 'rec-all-456', got %q", body["id"])
+	}
+	if body["status"] != "queued" {
+		t.Errorf("expected status 'queued', got %q", body["status"])
+	}
+}
+
+func TestReconcileNotFound(t *testing.T) {
+	triggerer := newMockTriggerer("x")
+	triggerer.knownStacks = map[string]bool{"web": true}
+	srv := newTestServer(&Status{}, nil, triggerer)
+	rec := do(srv, "POST", "/api/v1/reconcile/nonexistent")
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if !strings.Contains(body["error"], "nonexistent") {
+		t.Errorf("expected error mentioning stack name, got %q", body["error"])
+	}
+}
+
+func TestReconcileNilTriggerer(t *testing.T) {
+	srv := newTestServer(&Status{}, nil, nil)
+	rec := do(srv, "POST", "/api/v1/reconcile/web")
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("expected 501, got %d", rec.Code)
+	}
+}
+
+func TestReconcileAllNilTriggerer(t *testing.T) {
+	srv := newTestServer(&Status{}, nil, nil)
+	rec := do(srv, "POST", "/api/v1/reconcile")
+
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("expected 501, got %d", rec.Code)
+	}
+}
+
+func TestVersionEndpoint(t *testing.T) {
+	srv := newTestServer(&Status{}, nil, nil)
+	rec := do(srv, "GET", "/api/v1/version")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+
+	if _, ok := body["server"]; !ok {
+		t.Error("expected 'server' field in version response")
+	}
+	if _, ok := body["go"]; !ok {
+		t.Error("expected 'go' field in version response")
+	}
+	if !strings.HasPrefix(body["go"], "go") {
+		t.Errorf("expected go version to start with 'go', got %q", body["go"])
+	}
+}
+
+func TestVersionContentType(t *testing.T) {
+	srv := newTestServer(&Status{}, nil, nil)
+	rec := do(srv, "GET", "/api/v1/version")
+
+	ct := rec.Header().Get("Content-Type")
+	if ct != "application/json" {
+		t.Errorf("expected application/json, got %q", ct)
+	}
+}
+
+// TestStatusConcurrency verifies no data races on Status under concurrent access.
+func TestStatusConcurrency(t *testing.T) {
+	status := &Status{}
+	const goroutines = 20
+
+	done := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		go func(i int) {
+			name := "stack"
+			status.UpdateStack(name, &StackState{Name: name, Status: "Ready"})
+			_ = status.GetStack(name)
+			_ = status.GetStacks()
+			done <- struct{}{}
+		}(i)
+	}
+	for i := 0; i < goroutines; i++ {
+		<-done
 	}
 }


### PR DESCRIPTION
## Summary

- **Pre/post deploy hooks** — generic shell command execution (SOPS decryption via hooks), process group cleanup, timeout, env var injection
- **Flux-style CLI** — single binary with `dockcd <verb> <resource> [name]` pattern (get, reconcile, suspend, resume, logs, stats, version)
- **REST API** — `/api/v1/stacks`, `/reconcile`, `/suspend`, `/resume`, `/version` endpoints
- **Async force-deploy** — `TriggerReconcile`/`TriggerReconcileAll` with detached context
- **Suspend/resume** — state persisted in JSON state file, survives restarts
- **Event bus** — lifecycle event distribution for future notifications/SSE
- **Config expansion** — hooks, branch, notification fields with `${VAR}` env substitution
- **CI** — Docker build verification step

## Stats

- 34 files changed, +8230/-318 lines
- 170 unit tests, 40 integration tests (all with `-race`)
- 3 new packages: `hooks`, `notify`, `client`
- 7 new API endpoints
- 8 CLI commands

## Test plan

- [x] `go test -race ./...` — 170 pass
- [x] `go test -tags integration -race ./internal/reconciler/` — 40 pass
- [x] `go build -ldflags "-X main.Version=0.2.0" ./cmd/dockcd/` — builds
- [x] Backward compat: `dockcd` with no args starts daemon
- [x] Backward compat: existing configs without new fields load correctly
- [x] Code review: two critical fixes applied (rollback hooks, async context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)